### PR TITLE
Restricting access to internal classes

### DIFF
--- a/src/main/java/com/spectralogic/ds3client/ConnectionDetailsImpl.java
+++ b/src/main/java/com/spectralogic/ds3client/ConnectionDetailsImpl.java
@@ -1,0 +1,80 @@
+package com.spectralogic.ds3client;
+
+import com.spectralogic.ds3client.models.Credentials;
+import com.spectralogic.ds3client.networking.ConnectionDetails;
+
+import java.net.URI;
+
+class ConnectionDetailsImpl implements ConnectionDetails {
+    static class Builder implements com.spectralogic.ds3client.utils.Builder<ConnectionDetailsImpl> {
+
+        private final String endpoint;
+        private final Credentials credentials;
+        private boolean secure = false;
+        private URI proxy = null;
+        private int retries = 5;
+
+        private Builder(final String endpoint, final Credentials credentials) {
+            this.endpoint = endpoint;
+            this.credentials = credentials;
+        }
+
+        public Builder withSecure(final boolean secure) {
+            this.secure = secure;
+            return this;
+        }
+
+        public Builder withProxy(final URI proxy) {
+            this.proxy = proxy;
+            return this;
+        }
+
+        public Builder withRedirectRetries(final int retries) {
+            this.retries = retries;
+            return this;
+        }
+
+        @Override
+        public ConnectionDetailsImpl build() {
+            return new ConnectionDetailsImpl(this);
+        }
+    }
+
+    private final String endpoint;
+    private final Credentials credentials;
+    private final boolean secure;
+    private final URI proxy;
+    private final int retries;
+
+    static Builder builder(final String uriEndpoint, final Credentials credentials) {
+        return new Builder(uriEndpoint, credentials);
+    }
+
+    private ConnectionDetailsImpl(final Builder builder) {
+        this.endpoint = builder.endpoint;
+        this.credentials = builder.credentials;
+        this.secure = builder.secure;
+        this.proxy = builder.proxy;
+        this.retries = builder.retries;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public Credentials getCredentials() {
+        return credentials;
+    }
+
+    public boolean isSecure() {
+        return secure;
+    }
+
+    public URI getProxy() {
+        return proxy;
+    }
+
+    public int getRetries() {
+        return retries;
+    }
+}

--- a/src/main/java/com/spectralogic/ds3client/Ds3Client.java
+++ b/src/main/java/com/spectralogic/ds3client/Ds3Client.java
@@ -24,7 +24,6 @@ import com.spectralogic.ds3client.commands.PutBucketResponse;
 import com.spectralogic.ds3client.commands.PutObjectRequest;
 import com.spectralogic.ds3client.commands.PutObjectResponse;
 import com.spectralogic.ds3client.models.Credentials;
-import com.spectralogic.ds3client.networking.ConnectionDetails;
 import com.spectralogic.ds3client.networking.NetworkClient;
 
 /**
@@ -119,10 +118,10 @@ public class Ds3Client {
          */
         @Override
 	    public Ds3Client build() {
-	        final ConnectionDetails.Builder connBuilder = ConnectionDetails.builder(endpoint, credentials)
+	        final ConnectionDetailsImpl.Builder connBuilder = ConnectionDetailsImpl.builder(endpoint, credentials)
 	            .withProxy(proxy).withSecure(secure).withRedirectRetries(retries);
 
-	        final NetworkClient netClient = new NetworkClient(connBuilder.build());
+	        final NetworkClient netClient = new NetworkClientImpl(connBuilder.build());
 	        return new Ds3Client(netClient);
 	    }
 	}

--- a/src/main/java/com/spectralogic/ds3client/Main.java
+++ b/src/main/java/com/spectralogic/ds3client/Main.java
@@ -1,5 +1,7 @@
 package com.spectralogic.ds3client;
 
+import com.spectralogic.ds3client.commands.GetObjectRequest;
+import com.spectralogic.ds3client.commands.GetObjectResponse;
 import com.spectralogic.ds3client.commands.GetServiceRequest;
 import com.spectralogic.ds3client.commands.GetServiceResponse;
 import com.spectralogic.ds3client.models.Bucket;
@@ -10,13 +12,18 @@ import java.security.SignatureException;
 
 class Main {
     public static void main(String[] args) throws IOException, SignatureException {
-        final Ds3Client client = Ds3Client.builder("192.168.56.101:8080",
+        final Ds3Client client = Ds3Client.builder("192.168.56.104:8088",
                                                   new Credentials("cnlhbg==", "3pxVeear")).withHttpSecure(false).build();
 
+
+            final GetObjectResponse response = client.getObject(new GetObjectRequest("bucket", "name"));
+
+            /*
              final GetServiceResponse response = client.getService(new GetServiceRequest());
 
              for(final Bucket bucket: response.getResult().getBuckets()) {
                      System.out.println(bucket.getName());
              }
+             */
     }
 }

--- a/src/main/java/com/spectralogic/ds3client/NetworkClientImpl.java
+++ b/src/main/java/com/spectralogic/ds3client/NetworkClientImpl.java
@@ -1,0 +1,119 @@
+package com.spectralogic.ds3client;
+
+import com.spectralogic.ds3client.commands.AbstractRequest;
+import com.spectralogic.ds3client.models.SignatureDetails;
+import com.spectralogic.ds3client.networking.ConnectionDetails;
+import com.spectralogic.ds3client.networking.NetUtils;
+import com.spectralogic.ds3client.networking.NetworkClient;
+import com.spectralogic.ds3client.utils.DateFormatter;
+import com.spectralogic.ds3client.utils.Signature;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHttpEntityEnclosingRequest;
+import org.apache.http.message.BasicHttpRequest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.security.SignatureException;
+import java.util.Map;
+
+class NetworkClientImpl implements NetworkClient {
+    final static private String HOST = "HOST";
+    final static private String DATE = "DATE";
+    final static private String AUTHORIZATION = "Authorization";
+    final static private String CONTENT_TYPE = "Content-Type";
+
+    final private ConnectionDetails connectionDetails;
+
+    NetworkClientImpl(final ConnectionDetails connectionDetails) {
+        this.connectionDetails = connectionDetails;
+    }
+
+    public ConnectionDetails getConnectionDetails() {
+        return connectionDetails;
+    }
+
+    public CloseableHttpResponse getResponse(final AbstractRequest request) throws IOException, SignatureException {
+        final HttpHost host = getHost(connectionDetails);
+        final HttpRequest httpRequest = getHttpRequest(request);
+        final String date = DateFormatter.dateToRfc882();
+
+        final CloseableHttpClient httpClient = HttpClients.createDefault();
+
+        httpRequest.addHeader(HOST, NetUtils.buildHostField(connectionDetails));
+        httpRequest.addHeader(DATE, date);
+        httpRequest.addHeader(CONTENT_TYPE, request.getContentType().toString());
+        for(final Map.Entry<String, String> header: request.getHeaders().entrySet()) {
+            httpRequest.addHeader(header.getKey(), header.getValue());
+        }
+
+        final SignatureDetails sigDetails = new SignatureDetails(request.getVerb(), request.getMd5(), request.getContentType().toString(), date, "", request.getPath(),connectionDetails.getCredentials());
+        httpRequest.addHeader(AUTHORIZATION, getSignature(sigDetails));
+
+        return httpClient.execute(host, httpRequest, getContext());
+    }
+
+    private String getSignature(final SignatureDetails details) throws SignatureException {
+        return "AWS " + connectionDetails.getCredentials().getClientId() + ':' + Signature.signature(details);
+    }
+
+    private HttpHost getHost(final ConnectionDetails connectionDetails) throws MalformedURLException {
+        final URI proxyUri = connectionDetails.getProxy();
+        if(proxyUri != null) {
+            return new HttpHost(proxyUri.getHost(), proxyUri.getPort(), proxyUri.getScheme());
+        }
+
+        final URL url = NetUtils.buildUrl(connectionDetails, "/");
+        final int port = getPort(url);
+        return new HttpHost(url.getHost(), port, url.getProtocol());
+    }
+
+    private HttpClientContext getContext() {
+        final HttpClientContext context = new HttpClientContext();
+        final RequestConfig config = RequestConfig.custom().setCircularRedirectsAllowed(true).setMaxRedirects(connectionDetails.getRetries()).build();
+
+        context.setRequestConfig(config);
+        return context;
+    }
+
+    private int getPort(final URL url) {
+        final int port = url.getPort();
+        if(port < 0) {
+            return 80;
+        }
+        return port;
+    }
+
+    private HttpRequest getHttpRequest(final AbstractRequest request) {
+        final String verb = request.getVerb().toString();
+        final InputStream stream = request.getStream();
+        final Map<String, String> queryParams = request.getQueryParams();
+        final String path;
+
+        if(queryParams.isEmpty()) {
+            path = request.getPath();
+        }
+        else {
+            path = request.getPath() + "?" + NetUtils.buildQueryString(queryParams);
+        }
+
+        if(stream != null) {
+            final HttpEntity entity = new InputStreamEntity(stream, request.getSize(), request.getContentType());
+            final BasicHttpEntityEnclosingRequest httpRequest = new BasicHttpEntityEnclosingRequest(verb, path);
+            httpRequest.setEntity(entity);
+            return httpRequest;
+        }
+
+        return new BasicHttpRequest(verb, path);
+    }
+}

--- a/src/main/java/com/spectralogic/ds3client/networking/ConnectionDetails.java
+++ b/src/main/java/com/spectralogic/ds3client/networking/ConnectionDetails.java
@@ -4,79 +4,16 @@ import com.spectralogic.ds3client.models.Credentials;
 
 import java.net.URI;
 
+public interface ConnectionDetails {
+    public String getEndpoint();
 
-public class ConnectionDetails {
-	
-    public static class Builder implements com.spectralogic.ds3client.utils.Builder<ConnectionDetails> {
+    public Credentials getCredentials();
 
-        private final String endpoint;
-        private final Credentials credentials;
-        private boolean secure = false;
-        private URI proxy = null;
-        private int retries = 5;
+    public boolean isSecure();
 
-        public Builder(final String endpoint, final Credentials credentials) {
-            this.endpoint = endpoint;
-            this.credentials = credentials;
-        }
+    public URI getProxy();
 
-        public Builder withSecure(final boolean secure) {
-            this.secure = secure;
-            return this;
-        }
-
-        public Builder withProxy(final URI proxy) {
-            this.proxy = proxy;
-            return this;
-        }
-        
-        public Builder withRedirectRetries(final int retries) {
-        	this.retries = retries;
-        	return this;
-        }
-
-        @Override
-        public ConnectionDetails build() {
-            return new ConnectionDetails(this);
-        }
-    }
-	
-    private final String endpoint;
-    private final Credentials credentials;
-    private final boolean secure;
-    private final URI proxy;
-    private final int retries;
-
-    public static Builder builder(final String uriEndpoint, final Credentials credentials) {
-        return new Builder(uriEndpoint, credentials);
-    }
-
-    private ConnectionDetails(final Builder builder) {
-        this.endpoint = builder.endpoint;
-        this.credentials = builder.credentials;
-        this.secure = builder.secure;
-        this.proxy = builder.proxy;
-        this.retries = builder.retries;
-    }
-
-    public String getEndpoint() {
-        return endpoint;
-    }
-
-    public Credentials getCredentials() {
-        return credentials;
-    }
-
-    public boolean isSecure() {
-        return secure;
-    }
-
-    public URI getProxy() {
-        return proxy;
-    }
-
-    public int getRetries() {
-    	return retries;
-    }
-
+    public int getRetries();
 }
+	
+

--- a/src/main/java/com/spectralogic/ds3client/networking/NetworkClient.java
+++ b/src/main/java/com/spectralogic/ds3client/networking/NetworkClient.java
@@ -1,118 +1,12 @@
 package com.spectralogic.ds3client.networking;
 
 import com.spectralogic.ds3client.commands.AbstractRequest;
-import com.spectralogic.ds3client.models.SignatureDetails;
-import com.spectralogic.ds3client.utils.DateFormatter;
-import com.spectralogic.ds3client.utils.Signature;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
-import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicHttpEntityEnclosingRequest;
-import org.apache.http.message.BasicHttpRequest;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URL;
 import java.security.SignatureException;
-import java.util.Map;
 
-
-public class NetworkClient {
-
-    final static private String HOST = "HOST";
-    final static private String DATE = "DATE";
-    final static private String AUTHORIZATION = "Authorization";
-    final static private String CONTENT_TYPE = "Content-Type";
-
-    final private ConnectionDetails connectionDetails;
-
-    public NetworkClient(final ConnectionDetails connectionDetails) {
-        this.connectionDetails = connectionDetails;
-    }
-
-    public ConnectionDetails getConnectionDetails() {
-        return connectionDetails;
-    }
-
-    public CloseableHttpResponse getResponse(final AbstractRequest request) throws IOException, SignatureException {
-        final HttpHost host = getHost(connectionDetails);
-        final HttpRequest httpRequest = getHttpRequest(request);
-        final String date = DateFormatter.dateToRfc882();
-
-        final CloseableHttpClient httpClient = HttpClients.createDefault();
-
-        httpRequest.addHeader(HOST, NetUtils.buildHostField(connectionDetails));
-        httpRequest.addHeader(DATE, date);
-        httpRequest.addHeader(CONTENT_TYPE, request.getContentType().toString());
-        for(final Map.Entry<String, String> header: request.getHeaders().entrySet()) {
-            httpRequest.addHeader(header.getKey(), header.getValue());
-        }
-
-        final SignatureDetails sigDetails = new SignatureDetails(request.getVerb(), request.getMd5(), request.getContentType().toString(), date, "", request.getPath(),connectionDetails.getCredentials());
-        httpRequest.addHeader(AUTHORIZATION, getSignature(sigDetails));
-
-        return httpClient.execute(host, httpRequest, getContext());
-    }
-
-    private String getSignature(final SignatureDetails details) throws SignatureException {
-        return "AWS " + connectionDetails.getCredentials().getClientId() + ':' + Signature.signature(details);
-    }
-
-    private HttpHost getHost(final ConnectionDetails connectionDetails) throws MalformedURLException {
-        final URI proxyUri = connectionDetails.getProxy();
-        if(proxyUri != null) {
-            return new HttpHost(proxyUri.getHost(), proxyUri.getPort(), proxyUri.getScheme());
-        }
-
-        final URL url = NetUtils.buildUrl(connectionDetails, "/");
-        final int port = getPort(url);
-        return new HttpHost(url.getHost(), port, url.getProtocol());
-    }
-
-    private HttpClientContext getContext() {
-        final HttpClientContext context = new HttpClientContext();
-        final RequestConfig config = RequestConfig.custom().setCircularRedirectsAllowed(true).setMaxRedirects(connectionDetails.getRetries()).build();
-
-        context.setRequestConfig(config);
-        return context;
-    }
-
-    private int getPort(final URL url) {
-        final int port = url.getPort();
-        if(port < 0) {
-            return 80;
-        }
-        return port;
-    }
-
-    private HttpRequest getHttpRequest(final AbstractRequest request) {
-        final String verb = request.getVerb().toString();
-        final InputStream stream = request.getStream();
-        final Map<String, String> queryParams = request.getQueryParams();
-        final String path;
-
-        if(queryParams.isEmpty()) {
-            path = request.getPath();
-        }
-        else {
-            path = request.getPath() + "?" + NetUtils.buildQueryString(queryParams);
-        }
-
-        if(stream != null) {
-            final HttpEntity entity = new InputStreamEntity(stream, request.getSize(), request.getContentType());
-            final BasicHttpEntityEnclosingRequest httpRequest = new BasicHttpEntityEnclosingRequest(verb, path);
-            httpRequest.setEntity(entity);
-            return httpRequest;
-        }
-
-        return new BasicHttpRequest(verb, path);
-    }
+public interface NetworkClient {
+    public CloseableHttpResponse getResponse(final AbstractRequest request) throws IOException, SignatureException;
+    public ConnectionDetails getConnectionDetails();
 }

--- a/src/test/java/com/spectralogic/ds3client/ConnectionFixture.java
+++ b/src/test/java/com/spectralogic/ds3client/ConnectionFixture.java
@@ -1,4 +1,4 @@
-package com.spectralogic.ds3client.fixtures;
+package com.spectralogic.ds3client;
 
 import com.spectralogic.ds3client.networking.ConnectionDetails;
 import com.spectralogic.ds3client.models.Credentials;
@@ -10,6 +10,6 @@ public class ConnectionFixture {
     }
 
     public static ConnectionDetails getConnection(final int port) {
-        return ConnectionDetails.builder("localhost:" + port, new Credentials("id", "key")).build();
+        return ConnectionDetailsImpl.builder("localhost:" + port, new Credentials("id", "key")).build();
     }
 }

--- a/src/test/java/com/spectralogic/ds3client/utils/NetUtils_Test.java
+++ b/src/test/java/com/spectralogic/ds3client/utils/NetUtils_Test.java
@@ -2,7 +2,7 @@ package com.spectralogic.ds3client.utils;
 
 
 import com.spectralogic.ds3client.BulkCommand;
-import com.spectralogic.ds3client.fixtures.ConnectionFixture;
+import com.spectralogic.ds3client.ConnectionFixture;
 import com.spectralogic.ds3client.networking.NetUtils;
 import org.junit.Test;
 


### PR DESCRIPTION
This merge will restrict access to the `NetworkClient` and the `ConnectionDetails` objects so that consumers of the SDK cannot create those classes directly.
