### PR TITLE
Working through changes made to the lastest simulator vm.  

### DIFF
--- a/src/main/java/com/spectralogic/ds3client/commands/GetObjectRequest.java
+++ b/src/main/java/com/spectralogic/ds3client/commands/GetObjectRequest.java
@@ -18,6 +18,8 @@ package com.spectralogic.ds3client.commands;
 import com.spectralogic.ds3client.HttpVerb;
 import org.apache.http.entity.ContentType;
 
+import java.util.UUID;
+
 /**
  * Retrieves an object from DS3.  This should always be used within the context of a BulkGet command.
  * If not performance will be impacted.
@@ -43,18 +45,22 @@ public class GetObjectRequest extends AbstractRequest {
 
     private final String bucketName;
     private final String objectName;
-    private Range byteRange;
+    private final UUID jobId;
+    private Range byteRange = null;
 
-    /**
-     * We plan to mark this deprecated to encourage users to use the constructor
-     * that takes a job Id. We will still need this method for single Put
-     * operations, but the preferred method is to use the put request in the
-     * context of a bulk request.
-     */
+    @Deprecated
     public GetObjectRequest(final String bucketName, final String objectName) {
+        this(bucketName, objectName, null);
+    }
+
+    public GetObjectRequest(final String bucketName, final String objectName, final UUID jobId) {
         this.bucketName = bucketName;
         this.objectName = objectName;
-        this.byteRange = null;
+        this.jobId = jobId;
+
+        if(jobId != null) {
+            this.getQueryParams().put("job", jobId.toString());
+        }
     }
 
     /**
@@ -91,5 +97,9 @@ public class GetObjectRequest extends AbstractRequest {
     @Override
     public HttpVerb getVerb() {
         return HttpVerb.GET;
+    }
+
+    public UUID getJobId() {
+        return this.jobId;
     }
 }

--- a/src/main/java/com/spectralogic/ds3client/commands/PutObjectRequest.java
+++ b/src/main/java/com/spectralogic/ds3client/commands/PutObjectRequest.java
@@ -18,19 +18,31 @@ package com.spectralogic.ds3client.commands;
 import com.spectralogic.ds3client.HttpVerb;
 
 import java.io.InputStream;
+import java.util.UUID;
 
 public class PutObjectRequest extends AbstractRequest {
 
     private final String bucketName;
     private final String objectName;
+    private final UUID jobId;
     private final InputStream stream;
     private final long size;
 
+    @Deprecated
     public PutObjectRequest(final String bucketName, final String objectName, final long size, final InputStream stream) {
+        this(bucketName,objectName, null, size, stream);
+    }
+
+    public PutObjectRequest(final String bucketName, final String objectName, final UUID jobId, final long size, final InputStream stream) {
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.stream = stream;
         this.size = size;
+        this.jobId = jobId;
+
+        if(jobId != null) {
+            this.getQueryParams().put("job", jobId.toString());
+        }
     }
 
     @Override
@@ -51,5 +63,9 @@ public class PutObjectRequest extends AbstractRequest {
     @Override
     public InputStream getStream() {
         return stream;
+    }
+
+    public UUID getJobId() {
+        return this.jobId;
     }
 }

--- a/src/main/java/com/spectralogic/ds3client/models/Ds3Object.java
+++ b/src/main/java/com/spectralogic/ds3client/models/Ds3Object.java
@@ -49,6 +49,7 @@ public class Ds3Object  {
      */
     public Ds3Object(final String name) {
         this.name = name;
+        this.size = 0;
     }
 
     public String getName() {

--- a/src/main/java/com/spectralogic/ds3client/models/Objects.java
+++ b/src/main/java/com/spectralogic/ds3client/models/Objects.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3client.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 import java.util.Iterator;
@@ -23,6 +24,9 @@ import java.util.List;
 
 @JacksonXmlRootElement(localName="objects")
 public class Objects implements Iterable<Ds3Object> {
+
+    @JacksonXmlProperty
+    private String serverid; //This is not camel cased to match the xml attribute that is returned.
 
     @JsonProperty("")
     private List<Ds3Object> object;
@@ -33,6 +37,14 @@ public class Objects implements Iterable<Ds3Object> {
 
     public void setObject(final List<Ds3Object> object) {
         this.object = object;
+    }
+
+    public String getServerid() {
+        return serverid;
+    }
+
+    public void setServerid(final String serverid) {
+        this.serverid = serverid;
     }
 
     public String toString() {

--- a/src/main/java/com/spectralogic/ds3client/serializer/XmlOutput.java
+++ b/src/main/java/com/spectralogic/ds3client/serializer/XmlOutput.java
@@ -57,11 +57,13 @@ public class XmlOutput {
     }
 
     public static String toXml(final Objects objects, final BulkCommand command) throws XmlProcessingException {
+        /*
         if (command == BulkCommand.GET) {
             final FilterProvider filters = new SimpleFilterProvider().addFilter("sizeFilter",
                     SimpleBeanPropertyFilter.serializeAllExcept("size"));
             return XmlOutput.toXml(objects, filters);
         }
+        */
         return XmlOutput.toXml(objects);
     }
 


### PR DESCRIPTION
This adds support for capturing the serverid.  Adds the ability to set the job query param on gets a puts.  Makes those the default and marks the original method as deprecated.  We can't remove it out right since some special cases for naked primes are needed.
