### PR TITLE
Fixed international signature string creation.

### DIFF
--- a/sdk/src/main/java/com/spectralogic/ds3client/NetworkClientImpl.java
+++ b/sdk/src/main/java/com/spectralogic/ds3client/NetworkClientImpl.java
@@ -15,11 +15,13 @@
 
 package com.spectralogic.ds3client;
 
+import com.google.common.net.UrlEscapers;
 import com.spectralogic.ds3client.commands.Ds3Request;
 import com.spectralogic.ds3client.models.SignatureDetails;
 import com.spectralogic.ds3client.networking.*;
 import com.spectralogic.ds3client.utils.DateFormatter;
 import com.spectralogic.ds3client.utils.Signature;
+
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpStatus;
@@ -167,7 +169,7 @@ class NetworkClientImpl implements NetworkClient {
                 this.ds3Request.getContentType().toString(),
                 date,
                 "",
-                this.ds3Request.getPath(),
+                UrlEscapers.urlFragmentEscaper().escape(this.ds3Request.getPath()),
                 NetworkClientImpl.this.connectionDetails.getCredentials()
             )));
         }

--- a/sdk/src/main/java/com/spectralogic/ds3client/utils/Signature.java
+++ b/sdk/src/main/java/com/spectralogic/ds3client/utils/Signature.java
@@ -16,11 +16,13 @@
 package com.spectralogic.ds3client.utils;
 
 import com.spectralogic.ds3client.models.SignatureDetails;
+
 import org.apache.commons.codec.binary.Base64;
+
+import java.security.SignatureException;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import java.security.SignatureException;
 
 public class Signature {
 
@@ -52,7 +54,7 @@ public class Signature {
             // compute the hmac on input data bytes
             final byte[] rawHmac = mac.doFinal(data.getBytes());
             result = Base64.encodeBase64String(rawHmac);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new SignatureException("Failed to generate HMAC : " + e.getMessage());
         }
         return result.trim();
@@ -64,7 +66,14 @@ public class Signature {
      */
     public static String signature(final SignatureDetails signatureDetails)
             throws SignatureException {
-
-        return calculateRFC2104HMAC(String.valueOf(signatureDetails.getVerb()) + '\n' + signatureDetails.getContentMd5() + '\n' + signatureDetails.getContentType() + '\n' + signatureDetails.getDate() + '\n' + signatureDetails.getCanonicalizedAmzHeaders() + signatureDetails.getCanonicalizedResource(), signatureDetails.getCredentials().getKey());
+        return calculateRFC2104HMAC(
+                String.valueOf(signatureDetails.getVerb()) + '\n'
+                    + signatureDetails.getContentMd5() + '\n'
+                    + signatureDetails.getContentType() + '\n'
+                    + signatureDetails.getDate() + '\n'
+                    + signatureDetails.getCanonicalizedAmzHeaders()
+                    + signatureDetails.getCanonicalizedResource(),
+                signatureDetails.getCredentials().getKey()
+        );
     }
 }


### PR DESCRIPTION
- Url encoded the request path when creating the string to sign.
- Cleaned up the mega one-liner string concatenation.
