### PR TITLE
Updated the Java client to escape the url.

### DIFF
--- a/sdk/src/main/java/com/spectralogic/ds3client/NetworkClientImpl.java
+++ b/sdk/src/main/java/com/spectralogic/ds3client/NetworkClientImpl.java
@@ -137,7 +137,7 @@ class NetworkClientImpl implements NetworkClient {
         }
 
         private String buildPath() {
-            String path = this.ds3Request.getPath();
+            String path = UrlEscapers.urlFragmentEscaper().escape(this.ds3Request.getPath());
             final Map<String, String> queryParams = this.ds3Request.getQueryParams();
             if (!queryParams.isEmpty()) {
                 path += "?" + NetUtils.buildQueryString(queryParams);


### PR DESCRIPTION
The apache http client does not encode its url when making a request.
This actually results in protocol violations when the path name
contains spaces.
