### PR TITLE
MultiObject Delete Support w/Minor Documentation Addition

### DIFF
--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/BucketIntegration_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/BucketIntegration_Test.java
@@ -53,83 +53,83 @@ import com.spectralogic.ds3client.serializer.XmlProcessingException;
 
 public class BucketIntegration_Test {
 
-	private static Ds3Client client;
+    private static Ds3Client client;
 
-	@BeforeClass
-	public static void startup() {
-		client = Util.fromEnv();
-	}
+    @BeforeClass
+    public static void startup() {
+        client = Util.fromEnv();
+    }
 
-	@Test
-	public void createBucket() throws IOException, SignatureException {
-		final String bucketName = "test_create_bucket";
-		client.putBucket(new PutBucketRequest(bucketName));
+    @Test
+    public void createBucket() throws IOException, SignatureException {
+        final String bucketName = "test_create_bucket";
+        client.putBucket(new PutBucketRequest(bucketName));
 
-		HeadBucketResponse response = null;
-		try {
-			response = client.headBucket(new HeadBucketRequest(bucketName));
-			assertThat(response.getStatus(),
-					is(HeadBucketResponse.Status.EXISTS));
-		} finally {
-			if (response != null) {
-				client.deleteBucket(new DeleteBucketRequest(bucketName));
-			}
-		}
-	}
+        HeadBucketResponse response = null;
+        try {
+            response = client.headBucket(new HeadBucketRequest(bucketName));
+            assertThat(response.getStatus(),
+                    is(HeadBucketResponse.Status.EXISTS));
+        } finally {
+            if (response != null) {
+                client.deleteBucket(new DeleteBucketRequest(bucketName));
+            }
+        }
+    }
 
-	@Test
-	public void deleteBucket() throws IOException, SignatureException {
-		final String bucketName = "test_delete_bucket";
-		client.putBucket(new PutBucketRequest(bucketName));
+    @Test
+    public void deleteBucket() throws IOException, SignatureException {
+        final String bucketName = "test_delete_bucket";
+        client.putBucket(new PutBucketRequest(bucketName));
 
-		HeadBucketResponse response = client.headBucket(new HeadBucketRequest(
-				bucketName));
-		assertThat(response.getStatus(), is(HeadBucketResponse.Status.EXISTS));
+        HeadBucketResponse response = client.headBucket(new HeadBucketRequest(
+                bucketName));
+        assertThat(response.getStatus(), is(HeadBucketResponse.Status.EXISTS));
 
-		client.deleteBucket(new DeleteBucketRequest(bucketName));
+        client.deleteBucket(new DeleteBucketRequest(bucketName));
 
-		response = client.headBucket(new HeadBucketRequest(bucketName));
-		assertThat(response.getStatus(),
-				is(HeadBucketResponse.Status.DOESNTEXIST));
-	}
+        response = client.headBucket(new HeadBucketRequest(bucketName));
+        assertThat(response.getStatus(),
+                is(HeadBucketResponse.Status.DOESNTEXIST));
+    }
 
-	@Test
-	public void emptyBucket() throws IOException, SignatureException {
-		final String bucketName = "test_empty_bucket";
+    @Test
+    public void emptyBucket() throws IOException, SignatureException {
+        final String bucketName = "test_empty_bucket";
 
-		try {
-			client.putBucket(new PutBucketRequest(bucketName));
+        try {
+            client.putBucket(new PutBucketRequest(bucketName));
 
-			final GetBucketResponse request = client
-					.getBucket(new GetBucketRequest(bucketName));
-			final ListBucketResult result = request.getResult();
-			assertThat(result.getContentsList(), is(notNullValue()));
-			assertTrue(result.getContentsList().isEmpty());
-		} finally {
-			client.deleteBucket(new DeleteBucketRequest(bucketName));
-		}
-	}
+            final GetBucketResponse request = client
+                    .getBucket(new GetBucketRequest(bucketName));
+            final ListBucketResult result = request.getResult();
+            assertThat(result.getContentsList(), is(notNullValue()));
+            assertTrue(result.getContentsList().isEmpty());
+        } finally {
+            client.deleteBucket(new DeleteBucketRequest(bucketName));
+        }
+    }
 
-	@Test
-	public void listContents() throws IOException, SignatureException,
-			XmlProcessingException, URISyntaxException {
-		final String bucketName = "test_contents_bucket";
+    @Test
+    public void listContents() throws IOException, SignatureException,
+            XmlProcessingException, URISyntaxException {
+        final String bucketName = "test_contents_bucket";
 
-		try {
-			client.putBucket(new PutBucketRequest(bucketName));
-			Util.loadBookTestData(client, bucketName);
+        try {
+            client.putBucket(new PutBucketRequest(bucketName));
+            Util.loadBookTestData(client, bucketName);
 
-			final GetBucketResponse response = client
-					.getBucket(new GetBucketRequest(bucketName));
+            final GetBucketResponse response = client
+                    .getBucket(new GetBucketRequest(bucketName));
 
-			final ListBucketResult result = response.getResult();
+            final ListBucketResult result = response.getResult();
 
-			assertFalse(result.getContentsList().isEmpty());
-			assertThat(result.getContentsList().size(), is(4));
-		} finally {
-			Util.deleteAllContents(client, bucketName);
-		}
-	}
+            assertFalse(result.getContentsList().isEmpty());
+            assertThat(result.getContentsList().size(), is(4));
+        } finally {
+            Util.deleteAllContents(client, bucketName);
+        }
+    }
 
     @Test
     public void getContents() throws IOException, SignatureException, URISyntaxException, XmlProcessingException {
@@ -146,12 +146,12 @@ public class BucketIntegration_Test {
             final UUID jobId = job.getJobId();
 
             job.transfer(new Ds3ClientHelpers.ObjectChannelBuilder() {
-				@Override
-				public SeekableByteChannel buildChannel(final String key) throws IOException {
-					final Path filePath = Files.createTempFile("ds3", key);
-					return Files.newByteChannel(filePath, StandardOpenOption.DELETE_ON_CLOSE, StandardOpenOption.WRITE);
-				}
-			});
+                @Override
+                public SeekableByteChannel buildChannel(final String key) throws IOException {
+                    final Path filePath = Files.createTempFile("ds3", key);
+                    return Files.newByteChannel(filePath, StandardOpenOption.DELETE_ON_CLOSE, StandardOpenOption.WRITE);
+                }
+            });
 
             final GetJobResponse jobResponse = client.getJob(new GetJobRequest(jobId));
             assertThat(jobResponse.getMasterObjectList().getStatus(), is(JobStatus.COMPLETED));
@@ -161,93 +161,93 @@ public class BucketIntegration_Test {
         }
     }
 
-	@Test
-	public void negativeDeleteNonEmptyBucket() throws IOException,
-			SignatureException, XmlProcessingException, URISyntaxException {
-		final String bucketName = "negative_test_delete_non_empty_bucket";
+    @Test
+    public void negativeDeleteNonEmptyBucket() throws IOException,
+            SignatureException, XmlProcessingException, URISyntaxException {
+        final String bucketName = "negative_test_delete_non_empty_bucket";
 
-		try {
-			// Create bucket and put objects (4 book .txt files) to it
-			client.putBucket(new PutBucketRequest(bucketName));
-			Util.loadBookTestData(client, bucketName);
+        try {
+            // Create bucket and put objects (4 book .txt files) to it
+            client.putBucket(new PutBucketRequest(bucketName));
+            Util.loadBookTestData(client, bucketName);
 
-			final GetBucketResponse get_response = client
-					.getBucket(new GetBucketRequest(bucketName));
-			final ListBucketResult get_result = get_response.getResult();
-			assertFalse(get_result.getContentsList().isEmpty());
-			assertThat(get_result.getContentsList().size(), is(4));
+            final GetBucketResponse get_response = client
+                    .getBucket(new GetBucketRequest(bucketName));
+            final ListBucketResult get_result = get_response.getResult();
+            assertFalse(get_result.getContentsList().isEmpty());
+            assertThat(get_result.getContentsList().size(), is(4));
 
-			// Attempt to delete bucket and catch expected
-			// FailedRequestException
-			try {
-				client.deleteBucket(new DeleteBucketRequest(bucketName));
-				fail("Should have thrown a FailedRequestException when trying to delete a non-empty bucket.");
-			} catch (FailedRequestException e) {
-				assertTrue(409 == e.getStatusCode());
-			}
-		} finally {
-			Util.deleteAllContents(client, bucketName);
-		}
-	}
+            // Attempt to delete bucket and catch expected
+            // FailedRequestException
+            try {
+                client.deleteBucket(new DeleteBucketRequest(bucketName));
+                fail("Should have thrown a FailedRequestException when trying to delete a non-empty bucket.");
+            } catch (FailedRequestException e) {
+                assertTrue(409 == e.getStatusCode());
+            }
+        } finally {
+            Util.deleteAllContents(client, bucketName);
+        }
+    }
 
-	@Test
-	public void negativeCreateBucketNameConflict() throws SignatureException,
-			IOException {
-		final String bucketName = "negative_test_create_bucket_duplicate_name";
+    @Test
+    public void negativeCreateBucketNameConflict() throws SignatureException,
+            IOException {
+        final String bucketName = "negative_test_create_bucket_duplicate_name";
 
-		client.putBucket(new PutBucketRequest(bucketName));
+        client.putBucket(new PutBucketRequest(bucketName));
 
-		// Attempt to create a bucket with a name conflicting with an existing
-		// bucket
-		try {
-			client.putBucket(new PutBucketRequest(bucketName));
-			fail("Should have thrown a FailedRequestException when trying to create a bucket with a duplicate name.");
-		} catch (FailedRequestException e) {
-			assertTrue(409 == e.getStatusCode());
-		} finally {
-			client.deleteBucket(new DeleteBucketRequest(bucketName));
-		}
-	}
-	
-	@Test
-	public void negativeDeleteNonExistentBucket() throws IOException,
-			SignatureException {
-		final String bucketName = "negative_test_delete_non_existent_bucket";
+        // Attempt to create a bucket with a name conflicting with an existing
+        // bucket
+        try {
+            client.putBucket(new PutBucketRequest(bucketName));
+            fail("Should have thrown a FailedRequestException when trying to create a bucket with a duplicate name.");
+        } catch (FailedRequestException e) {
+            assertTrue(409 == e.getStatusCode());
+        } finally {
+            client.deleteBucket(new DeleteBucketRequest(bucketName));
+        }
+    }
 
-		// Attempt to delete bucket and catch expected FailedRequestException
-		try {
-			client.deleteBucket(new DeleteBucketRequest(bucketName));
-			fail("Should have thrown a FailedRequestException when trying to delete a non-existent bucket.");
-		} catch (FailedRequestException e) {
-			assertTrue(404 == e.getStatusCode());
-		}
-	}
+    @Test
+    public void negativeDeleteNonExistentBucket() throws IOException,
+            SignatureException {
+        final String bucketName = "negative_test_delete_non_existent_bucket";
 
-	@Test
-	public void negativePutDuplicateObject() throws SignatureException,
-			IOException, XmlProcessingException, URISyntaxException {
-		final String bucketName = "negative_test_put_duplicate_object";
+        // Attempt to delete bucket and catch expected FailedRequestException
+        try {
+            client.deleteBucket(new DeleteBucketRequest(bucketName));
+            fail("Should have thrown a FailedRequestException when trying to delete a non-existent bucket.");
+        } catch (FailedRequestException e) {
+            assertTrue(404 == e.getStatusCode());
+        }
+    }
 
-		try {
-			client.putBucket(new PutBucketRequest(bucketName));
-			Util.loadBookTestData(client, bucketName);
+    @Test
+    public void negativePutDuplicateObject() throws SignatureException,
+            IOException, XmlProcessingException, URISyntaxException {
+        final String bucketName = "negative_test_put_duplicate_object";
 
-			final GetBucketResponse response = client
-					.getBucket(new GetBucketRequest(bucketName));
-			final ListBucketResult result = response.getResult();
-			assertFalse(result.getContentsList().isEmpty());
-			assertThat(result.getContentsList().size(), is(4));
+        try {
+            client.putBucket(new PutBucketRequest(bucketName));
+            Util.loadBookTestData(client, bucketName);
 
-			try {
-				Util.loadBookTestData(client, bucketName);
-				fail("Should have thrown a FailedRequestException when trying to put duplicate objects.");
-			} catch (FailedRequestException e) {
-				assertTrue(409 == e.getStatusCode());
-			}
-		} finally {
-			Util.deleteAllContents(client, bucketName);
-		}
-	}
+            final GetBucketResponse response = client
+                    .getBucket(new GetBucketRequest(bucketName));
+            final ListBucketResult result = response.getResult();
+            assertFalse(result.getContentsList().isEmpty());
+            assertThat(result.getContentsList().size(), is(4));
+
+            try {
+                Util.loadBookTestData(client, bucketName);
+                fail("Should have thrown a FailedRequestException when trying to put duplicate objects.");
+            } catch (FailedRequestException e) {
+                assertTrue(409 == e.getStatusCode());
+            }
+        } finally {
+            Util.deleteAllContents(client, bucketName);
+        }
+    }
 
     @Test
     public void deleteDirectory() throws IOException, SignatureException, XmlProcessingException {
@@ -266,17 +266,17 @@ public class BucketIntegration_Test {
             final Ds3ClientHelpers.Job putJob = helpers.startWriteJob(bucketName, objects);
 
             putJob.transfer(new Ds3ClientHelpers.ObjectChannelBuilder() {
-				@Override
-				public SeekableByteChannel buildChannel(String key) throws IOException {
-					final byte[] randomData = IOUtils.toByteArray(new RandomDataInputStream(120, 1024));
-					final ByteBuffer randomBuffer = ByteBuffer.wrap(randomData);
+                @Override
+                public SeekableByteChannel buildChannel(String key) throws IOException {
+                    final byte[] randomData = IOUtils.toByteArray(new RandomDataInputStream(120, 1024));
+                    final ByteBuffer randomBuffer = ByteBuffer.wrap(randomData);
 
-					final ByteArraySeekableByteChannel channel = new ByteArraySeekableByteChannel(1024);
-					channel.write(randomBuffer);
+                    final ByteArraySeekableByteChannel channel = new ByteArraySeekableByteChannel(1024);
+                    channel.write(randomBuffer);
 
-					return channel;
-				}
-			});
+                    return channel;
+                }
+            });
 
             final Iterable<Contents> objs = helpers.listObjects(bucketName, "dirA");
 
@@ -287,77 +287,73 @@ public class BucketIntegration_Test {
             final Iterable<Contents> filesLeft = helpers.listObjects(bucketName);
 
             assertTrue(Iterables.size(filesLeft) == 1);
-        }
-        finally {
+        } finally {
             Util.deleteAllContents(client, bucketName);
         }
     }
 
-	@Test
-	public void multiObjectDeleteNotQuiet() throws IOException, SignatureException, URISyntaxException, XmlProcessingException {
-		final String bucketName = "multi_object_delete";
-		final Ds3ClientHelpers wrapper = Ds3ClientHelpers.wrap(client);
+    @Test
+    public void multiObjectDeleteNotQuiet() throws IOException, SignatureException, URISyntaxException, XmlProcessingException {
+        final String bucketName = "multi_object_delete";
+        final Ds3ClientHelpers wrapper = Ds3ClientHelpers.wrap(client);
 
-		try {
-			wrapper.ensureBucketExists(bucketName);
-			Util.loadBookTestData(client, bucketName);
+        try {
+            wrapper.ensureBucketExists(bucketName);
+            Util.loadBookTestData(client, bucketName);
 
-			final Iterable<Contents> objs = wrapper.listObjects(bucketName);
-			final DeleteMultipleObjectsResponse response =  client.deleteMultipleObjects(new DeleteMultipleObjectsRequest(bucketName, objs).withQuiet(false));
-			assertThat(response, is(notNullValue()));
-			assertThat(response.getResult(), is(notNullValue()));
-			assertThat(response.getResult().getDeletedList().size(), is(4));
+            final Iterable<Contents> objs = wrapper.listObjects(bucketName);
+            final DeleteMultipleObjectsResponse response = client.deleteMultipleObjects(new DeleteMultipleObjectsRequest(bucketName, objs).withQuiet(false));
+            assertThat(response, is(notNullValue()));
+            assertThat(response.getResult(), is(notNullValue()));
+            assertThat(response.getResult().getDeletedList().size(), is(4));
 
-			final Iterable<Contents> filesLeft = wrapper.listObjects(bucketName);
-			assertTrue(Iterables.size(filesLeft) == 0);
-		}
-		finally {
-			Util.deleteAllContents(client, bucketName);
-		}
-	}
+            final Iterable<Contents> filesLeft = wrapper.listObjects(bucketName);
+            assertTrue(Iterables.size(filesLeft) == 0);
+        } finally {
+            Util.deleteAllContents(client, bucketName);
+        }
+    }
 
-	@Test
-	public void multiObjectDeleteQuiet() throws IOException, SignatureException, URISyntaxException, XmlProcessingException {
-		final String bucketName = "multi_object_delete";
-		final Ds3ClientHelpers wrapper = Ds3ClientHelpers.wrap(client);
+    @Test
+    public void multiObjectDeleteQuiet() throws IOException, SignatureException, URISyntaxException, XmlProcessingException {
+        final String bucketName = "multi_object_delete";
+        final Ds3ClientHelpers wrapper = Ds3ClientHelpers.wrap(client);
 
-		try {
-			wrapper.ensureBucketExists(bucketName);
-			Util.loadBookTestData(client, bucketName);
+        try {
+            wrapper.ensureBucketExists(bucketName);
+            Util.loadBookTestData(client, bucketName);
 
-			final Iterable<Contents> objs = wrapper.listObjects(bucketName);
-			final DeleteMultipleObjectsResponse response =  client.deleteMultipleObjects(new DeleteMultipleObjectsRequest(bucketName, objs).withQuiet(true));
-			assertThat(response, is(notNullValue()));
-			assertThat(response.getResult(), is(notNullValue()));
-			assertThat(response.getResult().getDeletedList(), is(nullValue()));
+            final Iterable<Contents> objs = wrapper.listObjects(bucketName);
+            final DeleteMultipleObjectsResponse response = client.deleteMultipleObjects(new DeleteMultipleObjectsRequest(bucketName, objs).withQuiet(true));
+            assertThat(response, is(notNullValue()));
+            assertThat(response.getResult(), is(notNullValue()));
+            assertThat(response.getResult().getDeletedList(), is(nullValue()));
 
-			final Iterable<Contents> filesLeft = wrapper.listObjects(bucketName);
-			assertTrue(Iterables.size(filesLeft) == 0);
-		}
-		finally {
-			Util.deleteAllContents(client, bucketName);
-		}
-	}
+            final Iterable<Contents> filesLeft = wrapper.listObjects(bucketName);
+            assertTrue(Iterables.size(filesLeft) == 0);
+        } finally {
+            Util.deleteAllContents(client, bucketName);
+        }
+    }
 
-	@Test
-	public void multiObjectDeleteOfUnknownObjects() throws IOException, SignatureException {
-		final String bucketName = "unknown_objects_delete";
-		final Ds3ClientHelpers wrapper = Ds3ClientHelpers.wrap(client);
+    @Test
+    public void multiObjectDeleteOfUnknownObjects() throws IOException, SignatureException {
+        final String bucketName = "unknown_objects_delete";
+        final Ds3ClientHelpers wrapper = Ds3ClientHelpers.wrap(client);
 
-		try {
-			wrapper.ensureBucketExists(bucketName);
+        try {
+            wrapper.ensureBucketExists(bucketName);
 
-			final List<String> objList = Lists.newArrayList("badObj1.txt", "badObj2.txt", "badObj3.txt");
-			final DeleteMultipleObjectsResponse response =  client.deleteMultipleObjects(new DeleteMultipleObjectsRequest(bucketName, objList));
-			assertThat(response, is(notNullValue()));
-			assertThat(response.getResult(), is(notNullValue()));
-			assertThat(response.getResult().getDeletedList(), is(nullValue()));
-			assertThat(response.getResult().getErrorList(), is(notNullValue()));
-			assertThat(response.getResult().getErrorList().size(), is(3));
+            final List<String> objList = Lists.newArrayList("badObj1.txt", "badObj2.txt", "badObj3.txt");
+            final DeleteMultipleObjectsResponse response = client.deleteMultipleObjects(new DeleteMultipleObjectsRequest(bucketName, objList));
+            assertThat(response, is(notNullValue()));
+            assertThat(response.getResult(), is(notNullValue()));
+            assertThat(response.getResult().getDeletedList(), is(nullValue()));
+            assertThat(response.getResult().getErrorList(), is(notNullValue()));
+            assertThat(response.getResult().getErrorList().size(), is(3));
 
-		}
-		finally {
-			Util.deleteAllContents(client, bucketName);
-		}
-	}
+        } finally {
+            Util.deleteAllContents(client, bucketName);
+        }
+    }
 }

--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/DataIntegrity_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/DataIntegrity_Test.java
@@ -76,8 +76,7 @@ public class DataIntegrity_Test {
 
             final String secondDigest = DigestUtils.sha256Hex(Files.newInputStream(tempDir.resolve(book)));
             assertThat(secondDigest, is(equalTo(digest)));
-        }
-        finally {
+        } finally {
             Util.deleteAllContents(client, bucketName);
         }
     }
@@ -89,7 +88,7 @@ public class DataIntegrity_Test {
         final long seed = 12345689;
         final int length = 2048;
 
-       sendAndVerifySingleFile(bucketName, randomFileName, seed, length);
+        sendAndVerifySingleFile(bucketName, randomFileName, seed, length);
     }
 
     @Test
@@ -173,8 +172,7 @@ public class DataIntegrity_Test {
 
             final String secondDigest = DigestUtils.sha256Hex(Files.newInputStream(tempDir.resolve(fileName)));
             assertThat(secondDigest, is(equalTo(digest)));
-        }
-        finally {
+        } finally {
             Util.deleteAllContents(client, bucketName);
         }
     }

--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/NotificationsIntegration_test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/NotificationsIntegration_test.java
@@ -129,8 +129,7 @@ public class NotificationsIntegration_test {
             assertThat(getResponse.getRegistration().getId(), is(notNullValue()));
 
             assertThat(client.deleteObjectPersistedNotification(new DeleteObjectPersistedNotificationRequest(registrationId)), is(notNullValue()));
-        }
-        finally {
+        } finally {
             Util.deleteAllContents(client, bucketName);
         }
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
@@ -110,8 +110,11 @@ public interface Ds3Client {
      * @throws IOException
      * @throws SignatureException
      */
-    public abstract DeleteObjectResponse deleteObject(
-            DeleteObjectRequest request) throws IOException, SignatureException;
+    public abstract DeleteObjectResponse deleteObject(DeleteObjectRequest request)
+            throws IOException, SignatureException;
+
+    public abstract DeleteMultipleObjectsResponse deleteMultipleObjects(DeleteMultipleObjectsRequest request)
+            throws IOException, SignatureException;
 
     /**
      * Retrieves an object from DS3

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientImpl.java
@@ -72,6 +72,11 @@ class Ds3ClientImpl implements Ds3Client {
     }
 
     @Override
+    public DeleteMultipleObjectsResponse deleteMultipleObjects(final DeleteMultipleObjectsRequest request) throws IOException, SignatureException {
+        return new DeleteMultipleObjectsResponse(this.netClient.getResponse(request));
+    }
+
+    @Override
     public GetObjectResponse getObject(final GetObjectRequest request) throws IOException, SignatureException {
         return new GetObjectResponse(
             this.netClient.getResponse(request),

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/NetworkClientImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/NetworkClientImpl.java
@@ -197,11 +197,24 @@ class NetworkClientImpl implements NetworkClient {
                 this.ds3Request.getContentType().toString(),
                 date,
                 canonicalizeAmzHeaders(this.ds3Request.getHeaders()),
-                UrlEscapers.urlFragmentEscaper().escape(this.ds3Request.getPath()),
+                canonicalizeResource(this.ds3Request.getPath(), this.ds3Request.getQueryParams()),
                 NetworkClientImpl.this.connectionDetails.getCredentials()
             )));
         }
-        
+
+
+        private String canonicalizeResource(final String path, final Map<String, String> queryParams) {
+
+            final StringBuilder canonicalizedResource = new StringBuilder();
+            canonicalizedResource.append(UrlEscapers.urlFragmentEscaper().escape(path));
+
+            if (queryParams.containsKey("delete")) {
+                canonicalizedResource.append("?delete");
+            }
+
+            return canonicalizedResource.toString();
+        }
+
 		private String canonicalizeAmzHeaders(
 				final Multimap<String, String> customHeaders) {
 			StringBuilder ret = new StringBuilder();

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteMultipleObjectsRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteMultipleObjectsRequest.java
@@ -31,7 +31,7 @@ public class DeleteMultipleObjectsRequest extends AbstractRequest {
     private final String bucketName;
     private final List<String> objects;
 
-    private boolean quiet = true;
+    private boolean quiet = false;
 
     private long size;
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteMultipleObjectsRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteMultipleObjectsRequest.java
@@ -1,0 +1,99 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.commands;
+
+import com.spectralogic.ds3client.HttpVerb;
+import com.spectralogic.ds3client.models.Contents;
+import com.spectralogic.ds3client.models.delete.Delete;
+import com.spectralogic.ds3client.models.delete.DeleteObject;
+import com.spectralogic.ds3client.serializer.XmlOutput;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeleteMultipleObjectsRequest extends AbstractRequest {
+
+    private final String bucketName;
+    private final List<String> objects;
+
+    private boolean quiet = true;
+
+    private long size;
+
+    public DeleteMultipleObjectsRequest(final String bucketName, final List<String> objects) {
+        this.bucketName = bucketName;
+        this.objects = objects;
+        this.getQueryParams().put("delete", null);
+    }
+
+    public DeleteMultipleObjectsRequest(final String bucketName, final Iterable<Contents> objs) {
+        this(bucketName, contentsToString(objs));
+    }
+
+    static private List<String> contentsToString(final Iterable<Contents> objs) {
+        final List<String> objKeyList = new ArrayList<>();
+        for (final Contents obj : objs) {
+            objKeyList.add(obj.getKey());
+        }
+        return objKeyList;
+    }
+
+    public DeleteMultipleObjectsRequest withQuiet(final boolean quiet) {
+        this.quiet = quiet;
+        return this;
+    }
+
+    @Override
+    public InputStream getStream() {
+
+        final Delete delete = new Delete();
+        delete.setQuiet(quiet);
+        final List<DeleteObject> deleteObjects = new ArrayList<>();
+
+        for(final String objName : objects) {
+            deleteObjects.add(new DeleteObject(objName));
+        }
+
+        delete.setDeleteObjectList(deleteObjects);
+
+        final String xmlOutput = XmlOutput.toXml(delete);
+        final byte[] stringBytes = xmlOutput.getBytes();
+        this.size = stringBytes.length;
+
+        return new ByteArrayInputStream(stringBytes);
+    }
+
+    @Override
+    public long getSize() {
+        return this.size;
+    }
+
+    @Override
+    public String getPath() {
+        return "/" + bucketName;
+    }
+
+    @Override
+    public HttpVerb getVerb() {
+        return HttpVerb.POST;
+    }
+
+    public List<String> getObjects() {
+        return objects;
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteMultipleObjectsResponse.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteMultipleObjectsResponse.java
@@ -1,0 +1,52 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.commands;
+
+import com.spectralogic.ds3client.models.delete.DeleteResult;
+import com.spectralogic.ds3client.networking.WebResponse;
+import com.spectralogic.ds3client.serializer.XmlOutput;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+
+public class DeleteMultipleObjectsResponse extends AbstractResponse {
+
+    private DeleteResult result;
+
+    public DeleteMultipleObjectsResponse(final WebResponse response) throws IOException {
+        super(response);
+    }
+
+    public DeleteResult getResult() {
+        return result;
+    }
+
+    @Override
+    protected void processResponse() throws IOException {
+        try {
+            this.checkStatusCode(200);
+            try (final InputStream content = getResponse().getResponseStream();
+                 final StringWriter writer = new StringWriter()) {
+                IOUtils.copy(content, writer, UTF8);
+                this.result = XmlOutput.fromXml(writer.toString(), DeleteResult.class);
+            }
+        } finally {
+            this.getResponse().close();
+        }
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpers.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpers.java
@@ -59,7 +59,7 @@ public abstract class Ds3ClientHelpers {
         public Job withMaxParallelRequests(int maxParallelRequests);
         
         /**
-         * Transfers the files in this job using the given seekable channel creator.
+         * Transfers the files in this job using the given seekable channel creator.  The is a blocking call.
          * @throws SignatureException
          * @throws IOException
          * @throws XmlProcessingException

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/delete/Delete.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/delete/Delete.java
@@ -1,0 +1,48 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.models.delete;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class Delete {
+
+    @JsonProperty("Quiet")
+    private boolean quiet;
+
+    @JsonProperty("Object")
+    private List<DeleteObject> deleteObjectList;
+
+    public Delete() {
+    }
+
+    public boolean isQuiet() {
+        return quiet;
+    }
+
+    public void setQuiet(final boolean quiet) {
+        this.quiet = quiet;
+    }
+
+    public List<DeleteObject> getDeleteObjectList() {
+        return deleteObjectList;
+    }
+
+    public void setDeleteObjectList(final List<DeleteObject> deleteObjectList) {
+        this.deleteObjectList = deleteObjectList;
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/delete/DeleteObject.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/delete/DeleteObject.java
@@ -1,0 +1,21 @@
+package com.spectralogic.ds3client.models.delete;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DeleteObject {
+
+    @JsonProperty("Key")
+    private String key;
+
+    public DeleteObject(final String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(final String key) {
+        this.key = key;
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/delete/DeleteResult.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/delete/DeleteResult.java
@@ -1,0 +1,45 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.models.delete;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class DeleteResult {
+
+    @JsonProperty("Deleted")
+    private List<Deleted> deletedList;
+
+    @JsonProperty("Error")
+    private List<Error> errorList;
+
+    public List<Deleted> getDeletedList() {
+        return deletedList;
+    }
+
+    public void setDeletedList(final List<Deleted> deletedList) {
+        this.deletedList = deletedList;
+    }
+
+    public List<Error> getErrorList() {
+        return errorList;
+    }
+
+    public void setErrorList(final List<Error> errorList) {
+        this.errorList = errorList;
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/delete/Deleted.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/delete/Deleted.java
@@ -1,0 +1,32 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.models.delete;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Deleted {
+
+    @JsonProperty("Key")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(final String key) {
+        this.key = key;
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/delete/Error.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/delete/Error.java
@@ -1,0 +1,54 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.models.delete;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Error {
+
+    @JsonProperty("Key")
+    private String key;
+
+    @JsonProperty("Code")
+    private String code;
+
+    @JsonProperty("Message")
+    private String message;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(final String key) {
+        this.key = key;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(final String code) {
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(final String message) {
+        this.message = message;
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/NetUtils.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/NetUtils.java
@@ -59,7 +59,10 @@ public class NetUtils {
         final SortedMap<String, String> sortedMap = new TreeMap<>(queryParams);
         final Iterator<String> stringIter = Iterators.transform(sortedMap.entrySet().iterator(), new Function<Map.Entry<String, String>, String>() {
             @Override
-            public String apply(Map.Entry<String, String> input) {
+            public String apply(final Map.Entry<String, String> input) {
+                if (input.getValue() == null || input.getValue().isEmpty()) {
+                    return input.getKey();
+                }
                 return input.getKey() + "=" + input.getValue();
             }
         });

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/MockNetwork.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/MockNetwork.java
@@ -124,7 +124,8 @@ public class MockNetwork implements NetworkClient {
         if (this.requestContent != null) {
             final InputStream stream = request.getStream();
             assertThat(stream, is(notNullValue()));
-            assertThat(IOUtils.toString(stream), is(this.requestContent));
+            final String computedStream = IOUtils.toString(stream);
+            assertThat(computedStream, is(this.requestContent));
         }
         return new MockedWebResponse(this.responseContent, this.statusCode, this.headers);
     }


### PR DESCRIPTION
This pull request adds support for the S3 Multi Object Delete API call.  Additionally there is a minor documentation improvement calling out that the Job transfer method is a blocking call.