### PR TITLE
Delete Tape Drive and Partition Call Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
 
 allprojects {
     group = 'com.spectralogic.ds3'
-    version = '1.1.0-RC1'
+    version = '1.1.0-RC2'
 }
 
 subprojects {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
@@ -228,7 +228,11 @@ public interface Ds3Client extends Closeable {
     ModifyJobResponse modifyJob(ModifyJobRequest request)
             throws IOException, SignatureException;
 
-    DeleteTapeDriveResponse deleteTapeDrive(DeleteTapeDriveRequest request) throws IOException, SignatureException;
+    DeleteTapeDriveResponse deleteTapeDrive(DeleteTapeDriveRequest request)
+            throws IOException, SignatureException;
+
+    DeleteTapePartitionResponse deleteTapePartition(DeleteTapePartitionRequest request)
+            throws IOException, SignatureException;
 
     NotificationResponse createObjectCachedNotification(CreateObjectCachedNotificationRequest request)
             throws IOException, SignatureException;

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
@@ -228,6 +228,8 @@ public interface Ds3Client extends Closeable {
     ModifyJobResponse modifyJob(ModifyJobRequest request)
             throws IOException, SignatureException;
 
+    DeleteTapeDriveResponse deleteTapeDrive(DeleteTapeDriveRequest request) throws IOException, SignatureException;
+
     NotificationResponse createObjectCachedNotification(CreateObjectCachedNotificationRequest request)
             throws IOException, SignatureException;
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientImpl.java
@@ -136,6 +136,11 @@ class Ds3ClientImpl implements Ds3Client {
     }
 
     @Override
+    public DeleteTapePartitionResponse deleteTapePartition(final DeleteTapePartitionRequest request) throws IOException, SignatureException {
+        return new DeleteTapePartitionResponse(this.netClient.getResponse(request));
+    }
+
+    @Override
     public NotificationResponse createObjectCachedNotification(final CreateObjectCachedNotificationRequest request) throws IOException, SignatureException {
         return new NotificationResponse(this.netClient.getResponse(request));
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientImpl.java
@@ -131,6 +131,11 @@ class Ds3ClientImpl implements Ds3Client {
     }
 
     @Override
+    public DeleteTapeDriveResponse deleteTapeDrive(final DeleteTapeDriveRequest request) throws IOException, SignatureException {
+        return new DeleteTapeDriveResponse(this.netClient.getResponse(request));
+    }
+
+    @Override
     public NotificationResponse createObjectCachedNotification(final CreateObjectCachedNotificationRequest request) throws IOException, SignatureException {
         return new NotificationResponse(this.netClient.getResponse(request));
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteTapeDriveRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteTapeDriveRequest.java
@@ -1,0 +1,36 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+package com.spectralogic.ds3client.commands;
+
+import com.spectralogic.ds3client.HttpVerb;
+
+public class DeleteTapeDriveRequest extends AbstractRequest {
+
+    private final String id;
+
+    public DeleteTapeDriveRequest(final String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getPath() {
+        return "/_rest_/tape_drive/" + id;
+    }
+
+    @Override
+    public HttpVerb getVerb() {
+        return HttpVerb.DELETE;
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteTapeDriveResponse.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteTapeDriveResponse.java
@@ -1,0 +1,34 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+package com.spectralogic.ds3client.commands;
+
+import com.spectralogic.ds3client.networking.WebResponse;
+
+import java.io.IOException;
+
+public class DeleteTapeDriveResponse extends AbstractResponse{
+    public DeleteTapeDriveResponse(final WebResponse response) throws IOException {
+        super(response);
+    }
+
+    @Override
+    protected void processResponse() throws IOException {
+        try {
+            this.checkStatusCode(204);
+        } finally {
+            this.getResponse().close();
+        }
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteTapePartitionRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteTapePartitionRequest.java
@@ -1,0 +1,36 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+package com.spectralogic.ds3client.commands;
+
+import com.spectralogic.ds3client.HttpVerb;
+
+public class DeleteTapePartitionRequest extends AbstractRequest {
+
+    private final String id;
+
+    public DeleteTapePartitionRequest(final String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getPath() {
+        return "/_rest_/tape_partition/" + this.id;
+    }
+
+    @Override
+    public HttpVerb getVerb() {
+        return HttpVerb.DELETE;
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteTapePartitionResponse.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/DeleteTapePartitionResponse.java
@@ -1,0 +1,34 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+package com.spectralogic.ds3client.commands;
+
+import com.spectralogic.ds3client.networking.WebResponse;
+
+import java.io.IOException;
+
+public class DeleteTapePartitionResponse extends AbstractResponse {
+    public DeleteTapePartitionResponse(final WebResponse response) throws IOException {
+        super(response);
+    }
+
+    @Override
+    protected void processResponse() throws IOException {
+        try {
+            this.checkStatusCode(204);
+        } finally {
+            this.getResponse().close();
+        }
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/GetAvailableJobChunksRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/GetAvailableJobChunksRequest.java
@@ -21,6 +21,8 @@ import java.util.UUID;
 public class GetAvailableJobChunksRequest extends AbstractRequest {
     private final UUID jobId;
 
+    private int preferredNumberOfChunks = 3;
+
     public UUID getJobId() {
         return jobId;
     }
@@ -28,6 +30,12 @@ public class GetAvailableJobChunksRequest extends AbstractRequest {
     public GetAvailableJobChunksRequest(final UUID jobId) {
         this.jobId = jobId;
         getQueryParams().put("job", jobId.toString());
+    }
+
+    public GetAvailableJobChunksRequest withPreferredNumberOfChunks(final int numberOfChunks) {
+        this.preferredNumberOfChunks = numberOfChunks;
+        this.getQueryParams().put("preferred_number_of_chunks", Integer.toString(numberOfChunks));
+        return this;
     }
 
     @Override
@@ -38,5 +46,9 @@ public class GetAvailableJobChunksRequest extends AbstractRequest {
     @Override
     public HttpVerb getVerb() {
         return HttpVerb.GET;
+    }
+
+    public int getPreferredNumberOfChunks() {
+        return preferredNumberOfChunks;
     }
 }

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
@@ -496,34 +496,34 @@ public class Ds3Client_Test {
         final List<JobInfo> jobs = response.getJobs();
         assertThat(jobs.size(), is(2));
         checkJob(
-            jobs.get(0),
-            "bucket_1",
-            69880L,
-            ChunkClientProcessingOrderGuarantee.IN_ORDER,
-            0L,
-            UUID.fromString("0807ff11-a9f6-4d55-bb92-b452c1bb00c7"),
-            69880L,
-            Priority.NORMAL,
-            RequestType.PUT,
-            "2014-09-04T17:23:45.000Z",
-            UUID.fromString("a7d3eff9-e6d2-4e37-8a0b-84e76211a18a"),
-            "spectra",
-            WriteOptimization.PERFORMANCE
+                jobs.get(0),
+                "bucket_1",
+                69880L,
+                ChunkClientProcessingOrderGuarantee.IN_ORDER,
+                0L,
+                UUID.fromString("0807ff11-a9f6-4d55-bb92-b452c1bb00c7"),
+                69880L,
+                Priority.NORMAL,
+                RequestType.PUT,
+                "2014-09-04T17:23:45.000Z",
+                UUID.fromString("a7d3eff9-e6d2-4e37-8a0b-84e76211a18a"),
+                "spectra",
+                WriteOptimization.PERFORMANCE
         );
         checkJob(
-            jobs.get(1),
-            "bucket_2",
-            0L,
-            ChunkClientProcessingOrderGuarantee.IN_ORDER,
-            0L,
-            UUID.fromString("c18554ba-e3a8-4905-91fd-3e6eec71bf45"),
-            69880L,
-            Priority.HIGH,
-            RequestType.GET,
-            "2014-09-04T17:24:04.000Z",
-            UUID.fromString("a7d3eff9-e6d2-4e37-8a0b-84e76211a18a"),
-            "spectra",
-            WriteOptimization.CAPACITY
+                jobs.get(1),
+                "bucket_2",
+                0L,
+                ChunkClientProcessingOrderGuarantee.IN_ORDER,
+                0L,
+                UUID.fromString("c18554ba-e3a8-4905-91fd-3e6eec71bf45"),
+                69880L,
+                Priority.HIGH,
+                RequestType.GET,
+                "2014-09-04T17:24:04.000Z",
+                UUID.fromString("a7d3eff9-e6d2-4e37-8a0b-84e76211a18a"),
+                "spectra",
+                WriteOptimization.CAPACITY
         );
     }
 
@@ -636,13 +636,23 @@ public class Ds3Client_Test {
     @Test
     public void modifyJob() throws SignatureException, IOException {
         checkMasterObjectList(
-            MockNetwork
-                .expecting(HttpVerb.PUT, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", null, null)
-                .returning(200, MASTER_OBJECT_LIST_XML)
-                .asClient()
-                .modifyJob(new ModifyJobRequest(MASTER_OBJECT_LIST_JOB_ID))
-                .getMasterObjectList()
+                MockNetwork
+                        .expecting(HttpVerb.PUT, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", null, null)
+                        .returning(200, MASTER_OBJECT_LIST_XML)
+                        .asClient()
+                        .modifyJob(new ModifyJobRequest(MASTER_OBJECT_LIST_JOB_ID))
+                        .getMasterObjectList()
         );
+    }
+
+    @Test
+    public void deleteTapeDrive() throws IOException, SignatureException {
+        final DeleteTapeDriveResponse response = MockNetwork
+                .expecting(HttpVerb.DELETE, "/_rest_/tape_drive/30a8dbf8-12e1-49dd-bede-0b4a7e1dd773", null, null)
+                .returning(204, "")
+                .asClient()
+                .deleteTapeDrive(new DeleteTapeDriveRequest("30a8dbf8-12e1-49dd-bede-0b4a7e1dd773"));
+        assertThat(response, notNullValue());
     }
 
     @Test

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
@@ -126,28 +126,28 @@ public class Ds3Client_Test {
         assertThat(contentsList, is(notNullValue()));
         assertThat(contentsList.size(), is(3));
         this.assertContentsEquals(
-            contentsList.get(0),
-            "user/hduser/gutenberg/20417.txt.utf-8",
-            "2014-01-03T13:26:47.000Z",
-            "8B19F3F41868106382A677C3435BDCE5",
-            674570,
-            "STANDARD"
+                contentsList.get(0),
+                "user/hduser/gutenberg/20417.txt.utf-8",
+                "2014-01-03T13:26:47.000Z",
+                "8B19F3F41868106382A677C3435BDCE5",
+                674570,
+                "STANDARD"
         );
         this.assertContentsEquals(
-            contentsList.get(1),
-            "user/hduser/gutenberg/5000.txt.utf-8",
-            "2014-01-03T13:26:47.000Z",
-            "9DE344878423E44B129730CE22B4B137",
-            1423803,
-            "STANDARD"
+                contentsList.get(1),
+                "user/hduser/gutenberg/5000.txt.utf-8",
+                "2014-01-03T13:26:47.000Z",
+                "9DE344878423E44B129730CE22B4B137",
+                1423803,
+                "STANDARD"
         );
         this.assertContentsEquals(
-            contentsList.get(2),
-            "user/hduser/gutenberg/4300.txt.utf-8",
-            "2014-01-03T13:26:47.000Z",
-            "33EE4519EA7DDAB27CA4E2742326D70B",
-            1573150,
-            "DEEP"
+                contentsList.get(2),
+                "user/hduser/gutenberg/4300.txt.utf-8",
+                "2014-01-03T13:26:47.000Z",
+                "33EE4519EA7DDAB27CA4E2742326D70B",
+                1573150,
+                "DEEP"
         );
     }
 
@@ -655,6 +655,15 @@ public class Ds3Client_Test {
         assertThat(response, notNullValue());
     }
 
+    @Test
+    public void deleteTapePartition() throws IOException, SignatureException {
+        final DeleteTapePartitionResponse response = MockNetwork
+                .expecting(HttpVerb.DELETE, "/_rest_/tape_partition/30a8dbf8-12e1-49dd-bede-0b4a7e1dd773", null, null)
+                .returning(204, "")
+                .asClient()
+                .deleteTapePartition(new DeleteTapePartitionRequest("30a8dbf8-12e1-49dd-bede-0b4a7e1dd773"));
+        assertThat(response, notNullValue());
+    }
     @Test
     public void newForNode() {
         final Ds3Client client = Ds3ClientBuilder.create("endpoint", new Credentials("access", "key")).build();

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
@@ -80,10 +80,10 @@ public class Ds3Client_Test {
         );
         
         final GetServiceResponse response = MockNetwork
-                .expecting(HttpVerb.GET, "/", null, null)
-                .returning(200, stringResponse)
-                .asClient()
-                .getService(new GetServiceRequest());
+            .expecting(HttpVerb.GET, "/", null, null)
+            .returning(200, stringResponse)
+            .asClient()
+            .getService(new GetServiceRequest());
         final ListAllMyBucketsResult result = response.getResult();
         assertThat(result.getOwner().getDisplayName(), is("ryan"));
         assertThat(result.getOwner().getId(), is("ryanid"));
@@ -100,10 +100,10 @@ public class Ds3Client_Test {
     @Test(expected = FailedRequestException.class)
     public void getBadService() throws IOException, SignatureException {
         MockNetwork
-                .expecting(HttpVerb.GET, "/", null, null)
-                .returning(400, "")
-                .asClient()
-                .getService(new GetServiceRequest());
+            .expecting(HttpVerb.GET, "/", null, null)
+            .returning(400, "")
+            .asClient()
+            .getService(new GetServiceRequest());
     }
 
     @Test
@@ -111,11 +111,11 @@ public class Ds3Client_Test {
         final String xmlResponse = "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>remoteTest16</Name><Prefix/><Marker/><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>user/hduser/gutenberg/20417.txt.utf-8</Key><LastModified>2014-01-03T13:26:47.000Z</LastModified><ETag>8B19F3F41868106382A677C3435BDCE5</ETag><Size>674570</Size><StorageClass>STANDARD</StorageClass><Owner><ID>ryan</ID><DisplayName>ryan</DisplayName></Owner></Contents><Contents><Key>user/hduser/gutenberg/5000.txt.utf-8</Key><LastModified>2014-01-03T13:26:47.000Z</LastModified><ETag>9DE344878423E44B129730CE22B4B137</ETag><Size>1423803</Size><StorageClass>STANDARD</StorageClass><Owner><ID>ryan</ID><DisplayName>ryan</DisplayName></Owner></Contents><Contents><Key>user/hduser/gutenberg/4300.txt.utf-8</Key><LastModified>2014-01-03T13:26:47.000Z</LastModified><ETag>33EE4519EA7DDAB27CA4E2742326D70B</ETag><Size>1573150</Size><StorageClass>DEEP</StorageClass><Owner><ID>ryan</ID><DisplayName>ryan</DisplayName></Owner></Contents></ListBucketResult>";
         
         final ListBucketResult result = MockNetwork
-                .expecting(HttpVerb.GET, "/remoteTest16", null, null)
-                .returning(200, xmlResponse)
-                .asClient()
-                .getBucket(new GetBucketRequest("remoteTest16"))
-                .getResult();
+            .expecting(HttpVerb.GET, "/remoteTest16", null, null)
+            .returning(200, xmlResponse)
+            .asClient()
+            .getBucket(new GetBucketRequest("remoteTest16"))
+            .getResult();
         
         assertThat(result.getName(), is("remoteTest16"));
         assertThat(result.getPrefix(), is(nullValue()));
@@ -126,28 +126,28 @@ public class Ds3Client_Test {
         assertThat(contentsList, is(notNullValue()));
         assertThat(contentsList.size(), is(3));
         this.assertContentsEquals(
-                contentsList.get(0),
-                "user/hduser/gutenberg/20417.txt.utf-8",
-                "2014-01-03T13:26:47.000Z",
-                "8B19F3F41868106382A677C3435BDCE5",
-                674570,
-                "STANDARD"
+            contentsList.get(0),
+            "user/hduser/gutenberg/20417.txt.utf-8",
+            "2014-01-03T13:26:47.000Z",
+            "8B19F3F41868106382A677C3435BDCE5",
+            674570,
+            "STANDARD"
         );
         this.assertContentsEquals(
-                contentsList.get(1),
-                "user/hduser/gutenberg/5000.txt.utf-8",
-                "2014-01-03T13:26:47.000Z",
-                "9DE344878423E44B129730CE22B4B137",
-                1423803,
-                "STANDARD"
+            contentsList.get(1),
+            "user/hduser/gutenberg/5000.txt.utf-8",
+            "2014-01-03T13:26:47.000Z",
+            "9DE344878423E44B129730CE22B4B137",
+            1423803,
+            "STANDARD"
         );
         this.assertContentsEquals(
-                contentsList.get(2),
-                "user/hduser/gutenberg/4300.txt.utf-8",
-                "2014-01-03T13:26:47.000Z",
-                "33EE4519EA7DDAB27CA4E2742326D70B",
-                1573150,
-                "DEEP"
+            contentsList.get(2),
+            "user/hduser/gutenberg/4300.txt.utf-8",
+            "2014-01-03T13:26:47.000Z",
+            "33EE4519EA7DDAB27CA4E2742326D70B",
+            1573150,
+            "DEEP"
         );
     }
 
@@ -168,28 +168,28 @@ public class Ds3Client_Test {
     @Test
     public void putBucket() throws IOException, SignatureException {
         MockNetwork
-                .expecting(HttpVerb.PUT, "/bucketName", null, null)
-                .returning(200, "")
-                .asClient()
-                .putBucket(new PutBucketRequest("bucketName"));
+            .expecting(HttpVerb.PUT, "/bucketName", null, null)
+            .returning(200, "")
+            .asClient()
+            .putBucket(new PutBucketRequest("bucketName"));
     }
     
     @Test
     public void deleteBucket() throws IOException, SignatureException {
         MockNetwork
-                .expecting(HttpVerb.DELETE, "/bucketName", null, null)
-                .returning(204, "")
-                .asClient()
-                .deleteBucket(new DeleteBucketRequest("bucketName"));
+            .expecting(HttpVerb.DELETE, "/bucketName", null, null)
+            .returning(204, "")
+            .asClient()
+            .deleteBucket(new DeleteBucketRequest("bucketName"));
     }
 
     @Test
     public void deleteObject() throws IOException, SignatureException {
         MockNetwork
-                .expecting(HttpVerb.DELETE, "/bucketName/my/file.txt", null, null)
-                .returning(204, "")
-                .asClient()
-                .deleteObject(new DeleteObjectRequest("bucketName", "my/file.txt"));
+            .expecting(HttpVerb.DELETE, "/bucketName/my/file.txt", null, null)
+            .returning(204, "")
+            .asClient()
+            .deleteObject(new DeleteObjectRequest("bucketName", "my/file.txt"));
     }
 
     @Test
@@ -200,19 +200,19 @@ public class Ds3Client_Test {
         final String payload = "<Delete><Quiet>false</Quiet><Object><Key>sample1.txt</Key></Object><Object><Key>sample2.txt</Key></Object></Delete>";
 
         final DeleteMultipleObjectsResponse response = MockNetwork
-                .expecting(HttpVerb.POST, "/bucketName", queryParams, payload)
-                .returning(200, "<DeleteResult>\n" +
-                        "  <Deleted>\n" +
-                        "    <Key>sample1.txt</Key>\n" +
-                        "  </Deleted>\n" +
-                        "  <Error>\n" +
-                        "    <Key>sample2.txt</Key>\n" +
-                        "    <Code>AccessDenied</Code>\n" +
-                        "    <Message>Access Denied</Message>\n" +
-                        "  </Error>\n" +
-                        "</DeleteResult>")
-                .asClient()
-                .deleteMultipleObjects(new DeleteMultipleObjectsRequest("bucketName", objsToDelete));
+            .expecting(HttpVerb.POST, "/bucketName", queryParams, payload)
+            .returning(200, "<DeleteResult>\n" +
+                "  <Deleted>\n" +
+                "    <Key>sample1.txt</Key>\n" +
+                "  </Deleted>\n" +
+                "  <Error>\n" +
+                "    <Key>sample2.txt</Key>\n" +
+                "    <Code>AccessDenied</Code>\n" +
+                "    <Message>Access Denied</Message>\n" +
+                "  </Error>\n" +
+                "</DeleteResult>")
+            .asClient()
+            .deleteMultipleObjects(new DeleteMultipleObjectsRequest("bucketName", objsToDelete));
         assertThat(response.getResult().getDeletedList().size(), is(1));
         assertThat(response.getResult().getErrorList().size(), is(1));
     }
@@ -220,10 +220,10 @@ public class Ds3Client_Test {
     @Test(expected = FailedRequestException.class)
     public void getBadBucket() throws IOException, SignatureException {
         MockNetwork
-                .expecting(HttpVerb.GET, "/remoteTest16", null, null)
-                .returning(400, "")
-                .asClient()
-                .getBucket(new GetBucketRequest("remoteTest16"));
+            .expecting(HttpVerb.GET, "/remoteTest16", null, null)
+            .returning(400, "")
+            .asClient()
+            .getBucket(new GetBucketRequest("remoteTest16"));
     }
 
     @Test
@@ -236,10 +236,10 @@ public class Ds3Client_Test {
         final ByteArraySeekableByteChannel resultChannel = new ByteArraySeekableByteChannel();
         final String stringResponse = "Response";
         MockNetwork
-                .expecting(HttpVerb.GET, "/bucketName/object", queryParams, null)
-                .returning(200, stringResponse)
-                .asClient()
-                .getObject(new GetObjectRequest("bucketName", "object", 0, UUID.fromString(jobIdString), resultChannel));
+            .expecting(HttpVerb.GET, "/bucketName/object", queryParams, null)
+            .returning(200, stringResponse)
+            .asClient()
+            .getObject(new GetObjectRequest("bucketName", "object", 0, UUID.fromString(jobIdString), resultChannel));
         assertThat(resultChannel.toString(), is(stringResponse));
     }
     
@@ -255,10 +255,10 @@ public class Ds3Client_Test {
         final String output = new String(fileBytes, Charset.forName("UTF-8"));
         final FileChannel channel = FileChannel.open(resourceFile.toPath(), StandardOpenOption.READ);
         MockNetwork
-                .expecting(HttpVerb.PUT, "/bucketName/objectName", queryParams, output)
-                .returning(200, "")
-                .asClient()
-                .putObject(new PutObjectRequest("bucketName", "objectName", UUID.fromString(jobIdString), fileBytes.length, 0, channel));
+            .expecting(HttpVerb.PUT, "/bucketName/objectName", queryParams, output)
+            .returning(200, "")
+            .asClient()
+            .putObject(new PutObjectRequest("bucketName", "objectName", UUID.fromString(jobIdString), fileBytes.length, 0, channel));
     }
     
     @Test
@@ -285,10 +285,10 @@ public class Ds3Client_Test {
         por.withMetaData("test2", "test2value");
         por.withMetaData("test2", "test2value2");
         MockNetwork
-                .expecting(HttpVerb.PUT, "/bucketName/objectName", queryParams, expectedRequestHeaders, output)
-                .returning(200, "")
-                .asClient()
-                .putObject(por);
+            .expecting(HttpVerb.PUT, "/bucketName/objectName", queryParams, expectedRequestHeaders, output)
+            .returning(200, "")
+            .asClient()
+            .putObject(por);
     }
 
     @Test
@@ -340,9 +340,9 @@ public class Ds3Client_Test {
         queryParams.put("operation", command.toString());
         
         final Ds3Client client = MockNetwork
-                .expecting(HttpVerb.PUT, "/_rest_/bucket/bulkTest", queryParams, expectedXmlBody)
-                .returning(200, xmlResponse)
-                .asClient();
+            .expecting(HttpVerb.PUT, "/_rest_/bucket/bulkTest", queryParams, expectedXmlBody)
+            .returning(200, xmlResponse)
+            .asClient();
         
         final List<Objects> objectListList = driver.performRestCall(client, "bulkTest", objects).getObjects();
         assertThat(objectListList.size(), is(1));
@@ -496,34 +496,34 @@ public class Ds3Client_Test {
         final List<JobInfo> jobs = response.getJobs();
         assertThat(jobs.size(), is(2));
         checkJob(
-                jobs.get(0),
-                "bucket_1",
-                69880L,
-                ChunkClientProcessingOrderGuarantee.IN_ORDER,
-                0L,
-                UUID.fromString("0807ff11-a9f6-4d55-bb92-b452c1bb00c7"),
-                69880L,
-                Priority.NORMAL,
-                RequestType.PUT,
-                "2014-09-04T17:23:45.000Z",
-                UUID.fromString("a7d3eff9-e6d2-4e37-8a0b-84e76211a18a"),
-                "spectra",
-                WriteOptimization.PERFORMANCE
+            jobs.get(0),
+            "bucket_1",
+            69880L,
+            ChunkClientProcessingOrderGuarantee.IN_ORDER,
+            0L,
+            UUID.fromString("0807ff11-a9f6-4d55-bb92-b452c1bb00c7"),
+            69880L,
+            Priority.NORMAL,
+            RequestType.PUT,
+            "2014-09-04T17:23:45.000Z",
+            UUID.fromString("a7d3eff9-e6d2-4e37-8a0b-84e76211a18a"),
+            "spectra",
+            WriteOptimization.PERFORMANCE
         );
         checkJob(
-                jobs.get(1),
-                "bucket_2",
-                0L,
-                ChunkClientProcessingOrderGuarantee.IN_ORDER,
-                0L,
-                UUID.fromString("c18554ba-e3a8-4905-91fd-3e6eec71bf45"),
-                69880L,
-                Priority.HIGH,
-                RequestType.GET,
-                "2014-09-04T17:24:04.000Z",
-                UUID.fromString("a7d3eff9-e6d2-4e37-8a0b-84e76211a18a"),
-                "spectra",
-                WriteOptimization.CAPACITY
+            jobs.get(1),
+            "bucket_2",
+            0L,
+            ChunkClientProcessingOrderGuarantee.IN_ORDER,
+            0L,
+            UUID.fromString("c18554ba-e3a8-4905-91fd-3e6eec71bf45"),
+            69880L,
+            Priority.HIGH,
+            RequestType.GET,
+            "2014-09-04T17:24:04.000Z",
+            UUID.fromString("a7d3eff9-e6d2-4e37-8a0b-84e76211a18a"),
+            "spectra",
+            WriteOptimization.CAPACITY
         );
     }
 
@@ -636,32 +636,32 @@ public class Ds3Client_Test {
     @Test
     public void modifyJob() throws SignatureException, IOException {
         checkMasterObjectList(
-                MockNetwork
-                        .expecting(HttpVerb.PUT, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", null, null)
-                        .returning(200, MASTER_OBJECT_LIST_XML)
-                        .asClient()
-                        .modifyJob(new ModifyJobRequest(MASTER_OBJECT_LIST_JOB_ID))
-                        .getMasterObjectList()
+            MockNetwork
+                .expecting(HttpVerb.PUT, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", null, null)
+                .returning(200, MASTER_OBJECT_LIST_XML)
+                .asClient()
+                .modifyJob(new ModifyJobRequest(MASTER_OBJECT_LIST_JOB_ID))
+                .getMasterObjectList()
         );
     }
 
     @Test
     public void deleteTapeDrive() throws IOException, SignatureException {
         final DeleteTapeDriveResponse response = MockNetwork
-                .expecting(HttpVerb.DELETE, "/_rest_/tape_drive/30a8dbf8-12e1-49dd-bede-0b4a7e1dd773", null, null)
-                .returning(204, "")
-                .asClient()
-                .deleteTapeDrive(new DeleteTapeDriveRequest("30a8dbf8-12e1-49dd-bede-0b4a7e1dd773"));
+            .expecting(HttpVerb.DELETE, "/_rest_/tape_drive/30a8dbf8-12e1-49dd-bede-0b4a7e1dd773", null, null)
+            .returning(204, "")
+            .asClient()
+            .deleteTapeDrive(new DeleteTapeDriveRequest("30a8dbf8-12e1-49dd-bede-0b4a7e1dd773"));
         assertThat(response, notNullValue());
     }
 
     @Test
     public void deleteTapePartition() throws IOException, SignatureException {
         final DeleteTapePartitionResponse response = MockNetwork
-                .expecting(HttpVerb.DELETE, "/_rest_/tape_partition/30a8dbf8-12e1-49dd-bede-0b4a7e1dd773", null, null)
-                .returning(204, "")
-                .asClient()
-                .deleteTapePartition(new DeleteTapePartitionRequest("30a8dbf8-12e1-49dd-bede-0b4a7e1dd773"));
+            .expecting(HttpVerb.DELETE, "/_rest_/tape_partition/30a8dbf8-12e1-49dd-bede-0b4a7e1dd773", null, null)
+            .returning(204, "")
+            .asClient()
+            .deleteTapePartition(new DeleteTapePartitionRequest("30a8dbf8-12e1-49dd-bede-0b4a7e1dd773"));
         assertThat(response, notNullValue());
     }
     @Test

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/utils/NetUtils_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/utils/NetUtils_Test.java
@@ -127,7 +127,6 @@ public class NetUtils_Test {
 
         final String result = NetUtils.buildQueryString(queryParams);
         assertThat(result, is("char=far&foo=bar"));
-
     }
 
     @Test


### PR DESCRIPTION
This pull request adds support for DeleteTapeDrive and DeleteTapePartition.  Additionally this call added the `preferred_number_of_chunks` query param to the `GetAvailableJobChunksRequest`