### PR TITLE
JSDK: Add a Build Time Flag to disable XML Validation

### DIFF
--- a/ds3-sdk/build.gradle
+++ b/ds3-sdk/build.gradle
@@ -1,3 +1,6 @@
+import java.nio.file.Files
+import java.nio.file.Path
+
 /*
  * ******************************************************************************
  *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
@@ -39,9 +42,26 @@ artifacts {
     archives shadowJar
 }
 
+task genConfigProperties << {
+    def productionBuild = System.getenv('productionBuild')
+    if (productionBuild == null) { productionBuild = 'false' }
+
+    File configFile = new File(sourceSets.main.output.resourcesDir, "/config.properties")
+    Path configPath = sourceSets.main.output.resourcesDir.toPath()
+    if (!Files.exists(configPath)) {
+        Files.createDirectories(configPath)
+    }
+
+    configFile.withWriter{out ->
+        out.writeLine("productionBuild=" + productionBuild.toString())
+    }
+}
+
 jar {
     from sourceSets.main.allJava
 }
+
+jar.dependsOn genConfigProperties
 
 dependencies {
     compile     'org.apache.httpcomponents:httpclient:4.3.2'

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/serializer/XmlOutput.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/serializer/XmlOutput.java
@@ -29,9 +29,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
 public class XmlOutput {
     private static final JacksonXmlModule module;
     private static final XmlMapper mapper;
+    static private final Logger LOG = LoggerFactory.getLogger(XmlOutput.class);
 
     static {
         module = new JacksonXmlModule();
@@ -48,7 +53,7 @@ public class XmlOutput {
         final Properties props = new Properties();
         final InputStream input = XmlOutput.class.getClassLoader().getResourceAsStream("/config.properties");
         if (input == null) {
-            System.err.println("Could not find property file.");
+            LOG.error("Could not find property file.");
         }
         else {
             try {
@@ -58,10 +63,10 @@ public class XmlOutput {
                     return true;
                 }
                 else {
-                    System.err.println("Unknown productionBuild value[" + productionBuild + "].  Defaulting to fail for unknown XML elements.");
+                    LOG.error("Unknown productionBuild value[" + productionBuild + "].  Defaulting to fail for unknown XML elements.");
                 }
             } catch (final IOException e) {
-                System.err.println("Failed to load property file.");
+                LOG.error("Failed to load property file.");
             }
         }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/serializer/XmlOutput.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/serializer/XmlOutput.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3client.serializer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
@@ -26,6 +27,7 @@ import com.spectralogic.ds3client.models.bulk.Ds3ObjectList;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Properties;
 
 public class XmlOutput {
     private static final JacksonXmlModule module;
@@ -37,6 +39,34 @@ public class XmlOutput {
         mapper = new XmlMapper(module);
         final SimpleFilterProvider filterProvider = new SimpleFilterProvider().setFailOnUnknownId(false);
         mapper.setFilters(filterProvider);
+        if (isProductionBuild()) {
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        }
+    }
+
+    protected static boolean isProductionBuild() {
+        final Properties props = new Properties();
+        final InputStream input = XmlOutput.class.getClassLoader().getResourceAsStream("/config.properties");
+        if (input == null) {
+            System.err.println("Could not find property file.");
+        }
+        else {
+            try {
+                props.load(input);
+                final String productionBuild = (String) props.get("productionBuild");
+                if (productionBuild.equals("true")) {
+                    return true;
+                }
+                else {
+                    System.err.println("Unknown productionBuild value[" + productionBuild + "].  Defaulting to fail for unknown XML elements.");
+                }
+            } catch (final IOException e) {
+                System.err.println("Failed to load property file.");
+            }
+        }
+
+        return false;
+
     }
 
     public static String toXml(final Object object) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/serializer/XmlOutput.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/serializer/XmlOutput.java
@@ -66,7 +66,7 @@ public class XmlOutput {
                     LOG.error("Unknown productionBuild value[" + productionBuild + "].  Defaulting to fail for unknown XML elements.");
                 }
             } catch (final IOException e) {
-                LOG.error("Failed to load property file.");
+                LOG.error("Failed to load property file: ", e);
             }
         }
 

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/serializer/XmlOutput_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/serializer/XmlOutput_Test.java
@@ -97,13 +97,16 @@ public class XmlOutput_Test {
         assertThat(result, is(expectedString));
     }
 
-    @Test
-    public void verifyProductionBuildProperty() {
-        assumeTrue(XmlOutput.isProductionBuild());
+    @Test(expected = java.io.IOException.class)
+    public void fromXmlWithInvalidElementThrowsExceptionInDevBuild() throws IOException {
+        final String xmlResponse = "<Object Name=\"file1\" InCache=\"false\" Length=\"256\" Offset=\"0\" TheAnswerToEverything=\"42\" />";
+        XmlOutput.fromXml(xmlResponse, BulkObject.class);
     }
 
-    @Test(expected = java.io.IOException.class)
-    public void fromXmlWithInvalidElement() throws IOException {
+    @Test
+    public void fromXmlWithInvalidElementIgnoredInProductionBuild() throws IOException {
+        assumeTrue(XmlOutput.isProductionBuild());
+
         final String xmlResponse = "<Object Name=\"file1\" InCache=\"false\" Length=\"256\" Offset=\"0\" TheAnswerToEverything=\"42\" />";
         XmlOutput.fromXml(xmlResponse, BulkObject.class);
     }

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/serializer/XmlOutput_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/serializer/XmlOutput_Test.java
@@ -27,6 +27,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 public class XmlOutput_Test {
@@ -99,6 +100,8 @@ public class XmlOutput_Test {
 
     @Test(expected = java.io.IOException.class)
     public void fromXmlWithInvalidElementThrowsExceptionInDevBuild() throws IOException {
+        assumeFalse(XmlOutput.isProductionBuild());
+
         final String xmlResponse = "<Object Name=\"file1\" InCache=\"false\" Length=\"256\" Offset=\"0\" TheAnswerToEverything=\"42\" />";
         XmlOutput.fromXml(xmlResponse, BulkObject.class);
     }

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/serializer/XmlOutput_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/serializer/XmlOutput_Test.java
@@ -27,6 +27,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 public class XmlOutput_Test {
 
@@ -94,5 +95,16 @@ public class XmlOutput_Test {
         final String result = XmlOutput.toXml(ds3ObjectList, BulkCommand.PUT);
 
         assertThat(result, is(expectedString));
+    }
+
+    @Test
+    public void verifyProductionBuildProperty() {
+        assumeTrue(XmlOutput.isProductionBuild());
+    }
+
+    @Test(expected = java.io.IOException.class)
+    public void fromXmlWithInvalidElement() throws IOException {
+        final String xmlResponse = "<Object Name=\"file1\" InCache=\"false\" Length=\"256\" Offset=\"0\" TheAnswerToEverything=\"42\" />";
+        XmlOutput.fromXml(xmlResponse, BulkObject.class);
     }
 }


### PR DESCRIPTION
denverm@dm-lt:~/code/github/ds3_java_sdk$ ./gradlew clean test
:ds3-sdk:clean
:ds3-sdk-integration:clean
:ds3-sdk-samples:clean UP-TO-DATE
:ds3-sdk:compileJava
:ds3-sdk:processResources UP-TO-DATE
:ds3-sdk:classes
:ds3-sdk:compileTestJava
:ds3-sdk:processTestResources
:ds3-sdk:testClasses
:ds3-sdk:test
:ds3-sdk:genConfigProperties
:ds3-sdk:jar
:ds3-sdk-integration:compileJava
:ds3-sdk-integration:processResources UP-TO-DATE
:ds3-sdk-integration:classes
:ds3-sdk-integration:compileTestJava
:ds3-sdk-integration:processTestResources
:ds3-sdk-integration:testClasses
:ds3-sdk-integration:test
:ds3-sdk-samples:compileJava
:ds3-sdk-samples:processResources UP-TO-DATE
:ds3-sdk-samples:classes
:ds3-sdk-samples:compileTestJava UP-TO-DATE
:ds3-sdk-samples:processTestResources UP-TO-DATE
:ds3-sdk-samples:testClasses UP-TO-DATE
:ds3-sdk-samples:test UP-TO-DATE

BUILD SUCCESSFUL

Total time: 54.887 secs

This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.7/userguide/gradle_daemon.html
denverm@dm-lt:~/code/github/ds3_java_sdk$ 
