### PR TITLE
Changing the FileObjectGetter so that is uses CREATE instead of CREAT…

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/FileObjectGetter.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/FileObjectGetter.java
@@ -48,7 +48,7 @@ public class FileObjectGetter implements ObjectChannelBuilder {
         return FileChannel.open(
             objectPath,
             StandardOpenOption.WRITE,
-            StandardOpenOption.CREATE_NEW,
+            StandardOpenOption.CREATE,
             StandardOpenOption.TRUNCATE_EXISTING
         );
     }


### PR DESCRIPTION
…E_NEW, which conflicts with TRUNCATE_EXISTING