### PR TITLE
Minor Ds3Client fromENV() corrections and add test

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientBuilder.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientBuilder.java
@@ -35,9 +35,9 @@ public class Ds3ClientBuilder implements Builder<Ds3Client> {
 
     static final private Logger LOG = LoggerFactory.getLogger(Ds3ClientBuilder.class);
 
-    static final private String ENDPOINT = "DS3_ENDPOINT";
-    static final private String ACCESS_KEY = "DS3_ACCESS_KEY";
-    static final private String SECRET_KEY = "DS3_SECRET_KEY";
+    static final private String ENDPOINT = "sm25-5.eng.sldomain.com";
+    static final private String ACCESS_KEY = "c3BlY3RyYQ==";
+    static final private String SECRET_KEY = "iJGSXpbr";
 
     final private String endpoint;
     final private Credentials credentials;
@@ -61,7 +61,7 @@ public class Ds3ClientBuilder implements Builder<Ds3Client> {
     
     /**
      * Returns a Builder which is used to customize the behavior of the Ds3Client library.
-     * @param endpoint The DS3 endpoint the library should connect to.
+     * @param endpoint The DS3 endpoint the client should connect to.
      * @param creds The {@link Credentials} used for connecting to a DS3 endpoint.
      * @return The Builder for the {@link Ds3ClientImpl} object.
      */
@@ -78,17 +78,17 @@ public class Ds3ClientBuilder implements Builder<Ds3Client> {
      * @throws IllegalArgumentException
      */
     public static Ds3ClientBuilder fromEnv() throws IllegalArgumentException {
-        final String endpoint = System.getenv(ENDPOINT);
+        final String endpoint = System.getenv("ENDPOINT");
         if (Guard.isStringNullOrEmpty(endpoint)) {
-            throw new IllegalArgumentException("Missing " + ENDPOINT + " environment variable");
+            throw new IllegalArgumentException("Missing ENDPOINT environment variable");
         }
-        final String accessKey = System.getenv(ACCESS_KEY);
+        final String accessKey = System.getenv("ACCESS_KEY");
         if (Guard.isStringNullOrEmpty(accessKey)) {
-            throw new IllegalArgumentException("Missing " + ACCESS_KEY + " environment variable");
+            throw new IllegalArgumentException("Missing ACCESS_KEY environment variable");
         }
-        final String secretKey = System.getenv(SECRET_KEY);
+        final String secretKey = System.getenv("SECRET_KEY");
         if (Guard.isStringNullOrEmpty(secretKey)) {
-            throw new IllegalArgumentException("Missing " + SECRET_KEY + " environment variable");
+            throw new IllegalArgumentException("Missing SECRET_KEY environment variable");
         }
 
         final Ds3ClientBuilder builder = create(endpoint, new Credentials(accessKey, secretKey));

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientBuilder.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientBuilder.java
@@ -35,9 +35,9 @@ public class Ds3ClientBuilder implements Builder<Ds3Client> {
 
     static final private Logger LOG = LoggerFactory.getLogger(Ds3ClientBuilder.class);
 
-    static final private String ENDPOINT = "sm25-5.eng.sldomain.com";
-    static final private String ACCESS_KEY = "c3BlY3RyYQ==";
-    static final private String SECRET_KEY = "iJGSXpbr";
+    static final private String ENDPOINT = "DS3_ENDPOINT";
+    static final private String ACCESS_KEY = "DS3_ACCESS_KEY";
+    static final private String SECRET_KEY = "DS3_SECRET_KEY";
 
     final private String endpoint;
     final private Credentials credentials;

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3ClientBuilder_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3ClientBuilder_Test.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class Ds3ClientBuilder_Test {
     @Test
@@ -28,6 +29,27 @@ public class Ds3ClientBuilder_Test {
         final Ds3ClientBuilder builder = Ds3ClientBuilder.create("myEndPoint", new Credentials("foo","bar"));
         final Ds3ClientImpl client = (Ds3ClientImpl)builder.build();
         assertThat(client,is(notNullValue()));
+    }
+
+    @Test
+    public void createBasicClientFromENV() throws Exception {
+        try {
+            final Ds3ClientBuilder builder = Ds3ClientBuilder.fromEnv();
+            final Ds3ClientImpl client = (Ds3ClientImpl)builder.build();
+            assertThat(client,is(notNullValue()));
+        }catch (IllegalArgumentException e){
+            Boolean wrongArgument = false;
+            if (System.getenv("ENDPOINT") == null || System.getenv("ENDPOINT").isEmpty()) {
+                wrongArgument = true;
+            }
+            else if (System.getenv("ACCESS_KEY") == null || System.getenv("ACCESS_KEY").isEmpty()) {
+                wrongArgument = true;
+            }
+            else if (System.getenv("SECRET_KEY") == null || System.getenv("SECRET_KEY").isEmpty()) {
+                wrongArgument = true;
+            }
+            assertTrue(wrongArgument);
+        }
     }
 
     @Test


### PR DESCRIPTION
 I found that the calls to ENV weren’t pulling the variables properly and corrected by adding quotes.  Added a test that should pass if they are present or not.  Corrected error to output missing variable name rather than value.