### PR TITLE
Split the command specific logic out of the spectra s3 pagination, an…

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/pagination/GetObjectsFullDetailsLoader.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/pagination/GetObjectsFullDetailsLoader.java
@@ -3,76 +3,25 @@ package com.spectralogic.ds3client.helpers.pagination;
 import com.spectralogic.ds3client.Ds3Client;
 import com.spectralogic.ds3client.commands.spectrads3.GetObjectsWithFullDetailsSpectraS3Request;
 import com.spectralogic.ds3client.commands.spectrads3.GetObjectsWithFullDetailsSpectraS3Response;
+import com.spectralogic.ds3client.helpers.pagination.commands.GetObjectsFullDetailsPaginatingCommand;
 import com.spectralogic.ds3client.models.DetailedS3Object;
-import com.spectralogic.ds3client.networking.FailedRequestException;
-import com.spectralogic.ds3client.networking.TooManyRetriesException;
-import com.spectralogic.ds3client.utils.Guard;
 import com.spectralogic.ds3client.utils.collections.LazyIterable;
 
-import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 public class GetObjectsFullDetailsLoader implements LazyIterable.LazyLoader<DetailedS3Object> {
 
-    private final Ds3Client client;
-    private final String bucket;
-    private final String folder;
-    private final boolean includePhysicalDetails;
-    private final int pageLength;
-    private final int retryCount;
-
-    private int pageOffset = 0;
-    private int pagingTotalResultCount;
-    private int totalItems = 0;
+    private final SpectraS3PaginationLoader<DetailedS3Object, GetObjectsWithFullDetailsSpectraS3Request, GetObjectsWithFullDetailsSpectraS3Response> paginator;
 
     public GetObjectsFullDetailsLoader(final Ds3Client client, final String bucket, final String folder, final boolean includePhysicalDetails, final int pageLength, final int retryCount) {
-        this.client = client;
-        this.bucket = bucket;
-        this.folder = folder;
-        this.includePhysicalDetails = includePhysicalDetails;
-        this.pageLength = pageLength;
-        this.retryCount = retryCount;
+        paginator = new SpectraS3PaginationLoader<>(
+                new GetObjectsFullDetailsPaginatingCommand(client, bucket, folder, includePhysicalDetails),
+                pageLength,
+                retryCount);
     }
 
     @Override
     public List<DetailedS3Object> getNextValues() {
-
-        int retryAttempt = 0;
-
-        while(true) {
-            if (totalItems > 0 && totalItems >= pagingTotalResultCount) {
-                return Collections.emptyList();
-            }
-            final GetObjectsWithFullDetailsSpectraS3Request request = new GetObjectsWithFullDetailsSpectraS3Request()
-                    .withIncludePhysicalPlacement(includePhysicalDetails)
-                    .withBucketId(bucket)
-                    .withPageLength(pageLength)
-                    .withPageOffset(pageOffset);
-            if (!Guard.isStringNullOrEmpty(folder)) {
-                request.withFolder(folder);
-            }
-            try {
-                final GetObjectsWithFullDetailsSpectraS3Response response = client.getObjectsWithFullDetailsSpectraS3(request);
-                pagingTotalResultCount = response.getPagingTotalResultCount();
-
-                final List<DetailedS3Object> detailedS3Objects = response.getDetailedS3ObjectListResult().getDetailedS3Objects();
-                totalItems += detailedS3Objects.size();
-
-                pageOffset++;
-
-                return detailedS3Objects;
-            } catch (final FailedRequestException e) {
-                // failure
-                throw new RuntimeException("Encountered a failure when attempting to get object list", e);
-            } catch (final IOException e) {
-                //error
-                if (retryAttempt >= retryCount) {
-                    //TODO need a proxied test to validate this retry logic
-                    throw new TooManyRetriesException("Failed to get the next set of objects from the getBucket request after " + retryCount + " retries", e);
-                }
-                retryAttempt++;
-            }
-        }
+        return paginator.getNextValues();
     }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/pagination/PaginatingCommand.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/pagination/PaginatingCommand.java
@@ -1,0 +1,13 @@
+package com.spectralogic.ds3client.helpers.pagination;
+
+import com.spectralogic.ds3client.commands.interfaces.AbstractPaginationRequest;
+import com.spectralogic.ds3client.commands.interfaces.AbstractPaginationResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface PaginatingCommand<E, T extends AbstractPaginationRequest, F extends AbstractPaginationResponse> {
+    T createRequest();
+    F invokeCommand(final T paginationRequest) throws IOException;
+    List<E> getResponseContents(F response);
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/pagination/SpectraS3PaginationLoader.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/pagination/SpectraS3PaginationLoader.java
@@ -1,0 +1,69 @@
+package com.spectralogic.ds3client.helpers.pagination;
+
+import com.spectralogic.ds3client.commands.interfaces.AbstractPaginationRequest;
+import com.spectralogic.ds3client.commands.interfaces.AbstractPaginationResponse;
+import com.spectralogic.ds3client.networking.FailedRequestException;
+import com.spectralogic.ds3client.networking.TooManyRetriesException;
+import com.spectralogic.ds3client.utils.collections.LazyIterable;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+public class SpectraS3PaginationLoader<T, E extends AbstractPaginationRequest, F extends AbstractPaginationResponse> implements LazyIterable.LazyLoader<T> {
+
+    private final PaginatingCommand<T, E, F> paginatingCommand;
+    private final int pageLength;
+    private final int retries;
+
+    private int pageOffset = 0;
+    private int pagingTotalResultCount;
+    private int totalItems = 0;
+
+    public SpectraS3PaginationLoader(final PaginatingCommand<T, E, F> paginatingCommand, final int pageLength, final int retries) {
+        this.paginatingCommand = paginatingCommand;
+        this.pageLength = pageLength;
+        this.retries = retries;
+    }
+
+    @Override
+    public List<T> getNextValues() {
+
+        int retryAttempt = 0;
+
+        while(true) {
+            if (totalItems > 0 && totalItems >= pagingTotalResultCount) {
+                return Collections.emptyList();
+            }
+
+            final E request = paginatingCommand.createRequest();
+
+            request.withPageLength(pageLength)
+                    .withPageOffset(pageOffset);
+
+            try {
+                final F response = paginatingCommand.invokeCommand(request);
+                pagingTotalResultCount = response.getPagingTotalResultCount();
+
+                final List<T> newValues = paginatingCommand.getResponseContents(response);
+
+                totalItems += newValues.size();
+
+                pageOffset++;
+
+                return newValues;
+            } catch (final FailedRequestException e) {
+                // failure
+                throw new RuntimeException("Encountered a failure when attempting to get object list", e);
+            } catch (final IOException e) {
+                //error
+                if (retryAttempt >= retries) {
+                    //TODO need a proxied test to validate this retry logic
+                    throw new TooManyRetriesException("Failed to get the next set of objects from the getBucket request after " + retries + " retries", e);
+                }
+                retryAttempt++;
+            }
+        }
+
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/pagination/commands/GetObjectsFullDetailsPaginatingCommand.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/pagination/commands/GetObjectsFullDetailsPaginatingCommand.java
@@ -1,0 +1,45 @@
+package com.spectralogic.ds3client.helpers.pagination.commands;
+
+import com.spectralogic.ds3client.Ds3Client;
+import com.spectralogic.ds3client.commands.spectrads3.GetObjectsWithFullDetailsSpectraS3Request;
+import com.spectralogic.ds3client.commands.spectrads3.GetObjectsWithFullDetailsSpectraS3Response;
+import com.spectralogic.ds3client.helpers.pagination.PaginatingCommand;
+import com.spectralogic.ds3client.models.DetailedS3Object;
+import com.spectralogic.ds3client.utils.Guard;
+
+import java.io.IOException;
+import java.util.List;
+
+public class GetObjectsFullDetailsPaginatingCommand implements PaginatingCommand<DetailedS3Object, GetObjectsWithFullDetailsSpectraS3Request, GetObjectsWithFullDetailsSpectraS3Response> {
+    private final Ds3Client client;
+    private final String bucket;
+    private final String folder;
+    private final boolean includePhysicalDetails;
+
+    public GetObjectsFullDetailsPaginatingCommand(final Ds3Client client, final String bucket, final String folder, final boolean includePhysicalDetails) {
+        this.client = client;
+        this.bucket = bucket;
+        this.folder = folder;
+        this.includePhysicalDetails = includePhysicalDetails;
+    }
+
+    @Override
+    public GetObjectsWithFullDetailsSpectraS3Request createRequest() {
+        final GetObjectsWithFullDetailsSpectraS3Request getObjectsWithFullDetailsSpectraS3Request = new GetObjectsWithFullDetailsSpectraS3Request().withBucketId(bucket).withIncludePhysicalPlacement(includePhysicalDetails);
+        if (Guard.isStringNullOrEmpty(folder)) {
+            return getObjectsWithFullDetailsSpectraS3Request;
+        } else {
+            return getObjectsWithFullDetailsSpectraS3Request.withFolder(folder);
+        }
+    }
+
+    @Override
+    public GetObjectsWithFullDetailsSpectraS3Response invokeCommand(final GetObjectsWithFullDetailsSpectraS3Request paginationRequest) throws IOException {
+        return client.getObjectsWithFullDetailsSpectraS3(paginationRequest);
+    }
+
+    @Override
+    public List<DetailedS3Object> getResponseContents(final GetObjectsWithFullDetailsSpectraS3Response response) {
+        return response.getDetailedS3ObjectListResult().getDetailedS3Objects();
+    }
+}


### PR DESCRIPTION
…d put it into it's own class so that the paginator can be made generic to more easily support other paginating commands.