### PR TITLE
Put object retries and http proxy

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+    sdk_proxy:
+        image: spectralogic/sdk_proxy:latest
+        environment:
+            - DS3_TARGET_SYSTEM_DNS_NAME
+            - HTTP_PROXY_PORT
+            - HTTP_PROXY_ADMIN_PORT
+        ports:
+            - "9080:9080"
+            - "9090:9090"
+    ds3_jsdk_docker_test:
+        image: denverm80/ds3_jsdk_docker_test:latest
+        environment:
+            - DS3_ENDPOINT
+            - DS3_SECRET_KEY
+            - DS3_ACCESS_KEY
+            - GIT_REPO
+            - GIT_BRANCH
+        dns: 
+            - 10.1.0.9
+
+
+

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -21,3 +21,6 @@ echo "cd ds3_java_sdk"
 cd ds3_java_sdk
 
 ./gradlew test
+
+curl -X PUT http://localhost:${HTTP_PROXY_ADMIN_PORT}/close >/dev/null 2>&1
+

--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/PutJobManagement_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/PutJobManagement_Test.java
@@ -17,28 +17,41 @@ package com.spectralogic.ds3client.integration;
 
 import com.google.common.collect.Lists;
 import com.spectralogic.ds3client.Ds3Client;
+import com.spectralogic.ds3client.Ds3ClientImpl;
 import com.spectralogic.ds3client.commands.*;
 import com.spectralogic.ds3client.commands.spectrads3.*;
 import com.spectralogic.ds3client.commands.spectrads3.notifications.*;
+import com.spectralogic.ds3client.exceptions.Ds3NoMoreRetriesException;
 import com.spectralogic.ds3client.helpers.Ds3ClientHelpers;
+import com.spectralogic.ds3client.helpers.FileObjectGetter;
+import com.spectralogic.ds3client.helpers.FileObjectPutter;
+import com.spectralogic.ds3client.helpers.ObjectCompletedListener;
 import com.spectralogic.ds3client.helpers.options.WriteJobOptions;
 import com.spectralogic.ds3client.integration.test.helpers.ABMTestHelper;
 import com.spectralogic.ds3client.integration.test.helpers.TempStorageIds;
 import com.spectralogic.ds3client.integration.test.helpers.TempStorageUtil;
 import com.spectralogic.ds3client.models.*;
 import com.spectralogic.ds3client.models.bulk.Ds3Object;
+import com.spectralogic.ds3client.networking.ConnectionDetails;
 import com.spectralogic.ds3client.networking.FailedRequestException;
+import com.spectralogic.ds3client.networking.NetworkClient;
+import com.spectralogic.ds3client.networking.NetworkClientImpl;
 import com.spectralogic.ds3client.utils.ByteArraySeekableByteChannel;
 import com.spectralogic.ds3client.utils.ResourceUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.*;
 
+import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -794,6 +807,123 @@ public class PutJobManagement_Test {
 
         } finally {
             deleteAllContents(client, BUCKET_NAME);
+        }
+    }
+
+    @Test
+    public void testWriteJobWithRetries() throws Exception
+    {
+        final Ds3ClientShim ds3ClientShim = new Ds3ClientShim((Ds3ClientImpl)client);
+
+        final Path tempDirectory = Files.createTempDirectory(Paths.get("."), null /* prefix */);
+
+        try {
+            final String DIR_NAME = "largeFiles/";
+            final String[] FILE_NAMES = new String[] { "lesmis-copies.txt" };
+
+            final Path dirPath = ResourceUtils.loadFileResource(DIR_NAME);
+
+            final List<String> bookTitles = new ArrayList<>();
+            final List<Ds3Object> objects = new ArrayList<>();
+            for (final String book : FILE_NAMES) {
+                final Path objPath = ResourceUtils.loadFileResource(DIR_NAME + book);
+                final long bookSize = Files.size(objPath);
+                final Ds3Object obj = new Ds3Object(book, bookSize);
+
+                bookTitles.add(book);
+                objects.add(obj);
+            }
+
+            final int maxNumRetriesForHttp503 = 1;
+            final Ds3ClientHelpers ds3ClientHelpers = Ds3ClientHelpers.wrap(ds3ClientShim, maxNumRetriesForHttp503);
+
+            final Ds3ClientHelpers.Job writeJob = ds3ClientHelpers.startWriteJob(BUCKET_NAME, objects);
+            writeJob.attachObjectCompletedListener(new ObjectCompletedListener() {
+                @Override
+                public void objectCompleted(final String name) {
+                    assertTrue(bookTitles.contains(name));
+                }
+            });
+
+            writeJob.transfer(new FileObjectPutter(dirPath));
+
+            final GetBucketResponse request = ds3ClientShim.getBucket(new GetBucketRequest(BUCKET_NAME));
+            final ListBucketResult result = request.getListBucketResult();
+
+            assertEquals(bookTitles.size(), result.getObjects().size());
+
+            for (final Contents contents : result.getObjects()) {
+                assertTrue(bookTitles.contains(contents.getKey()));
+            }
+
+            final Ds3ClientHelpers.Job readJob = Ds3ClientHelpers.wrap(ds3ClientShim, 1)
+                    .startReadAllJob(BUCKET_NAME);
+            readJob.attachObjectCompletedListener(new ObjectCompletedListener() {
+                @Override
+                public void objectCompleted(final String name) {
+                    assertTrue(bookTitles.contains(name));
+
+                    try {
+                        final File originalFile = ResourceUtils.loadFileResource(DIR_NAME + FILE_NAMES[0]).toFile();
+                        final File fileCopiedFromBP = Paths.get(tempDirectory.toString(), FILE_NAMES[0]).toFile();
+                        assertTrue(FileUtils.contentEquals(originalFile, fileCopiedFromBP));
+                    } catch (final URISyntaxException | IOException e) {
+                        fail("Failure trying to compare file we wrote to file we read.");
+                    }
+                }
+            });
+
+            readJob.transfer(new FileObjectGetter(tempDirectory));
+        } finally {
+            FileUtils.deleteDirectory(tempDirectory.toFile());
+            deleteAllContents(ds3ClientShim, BUCKET_NAME);
+        }
+    }
+
+    private static class Ds3ClientShim extends Ds3ClientImpl {
+        private static Method getNetClientMethod = null;
+
+        int numRetries = 0;
+
+        static {
+            try {
+                getNetClientMethod = Ds3ClientImpl.class.getDeclaredMethod("getNetClient");
+            } catch (final NoSuchMethodException e) {
+                fail("Could not find Ds3ClientImpl method getNetClient.");
+            }
+
+            getNetClientMethod.setAccessible(true);
+        }
+
+        public Ds3ClientShim(final NetworkClient netClient) {
+            super(netClient);
+        }
+
+        public Ds3ClientShim(final Ds3ClientImpl ds3ClientImpl) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+            this((NetworkClient)getNetClientMethod.invoke(ds3ClientImpl));
+        }
+
+        @Override
+        public PutObjectResponse putObject(final PutObjectRequest request) throws IOException {
+            if(numRetries++ >= 1) {
+                return super.putObject(request);
+            }
+
+            throw new Ds3NoMoreRetriesException(1);
+        }
+
+        @Override
+        public Ds3Client newForNode(final JobNode node) {
+            final ConnectionDetails newConnectionDetails;
+            try {
+                newConnectionDetails = ((NetworkClient)getNetClientMethod.invoke(this)).getConnectionDetails();
+                final NetworkClient newNetClient = new NetworkClientImpl(newConnectionDetails);
+                return new Ds3ClientShim(newNetClient);
+            } catch (final IllegalAccessException | InvocationTargetException e) {
+                fail("Failure trying to create Ds3Client used in verifying putObject retries: " + e.getMessage());
+            }
+
+            return null;
         }
     }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/ExceptionClassifier.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/ExceptionClassifier.java
@@ -1,0 +1,32 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.helpers;
+
+import java.io.IOException;
+
+public class ExceptionClassifier {
+    public static boolean isRecoverableException(final Throwable t) {
+        if(t instanceof IOException) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static boolean isUnrecoverableException(final Throwable t) {
+        return ! isRecoverableException(t);
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/ExceptionClassifier.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/ExceptionClassifier.java
@@ -17,13 +17,11 @@ package com.spectralogic.ds3client.helpers;
 
 import java.io.IOException;
 
-public class ExceptionClassifier {
-    public static boolean isRecoverableException(final Throwable t) {
-        if(t instanceof IOException) {
-            return true;
-        }
+public final class ExceptionClassifier {
+    private ExceptionClassifier() { }
 
-        return false;
+    public static boolean isRecoverableException(final Throwable t) {
+        return t instanceof IOException;
     }
 
     public static boolean isUnrecoverableException(final Throwable t) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobPartTrackerImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobPartTrackerImpl.java
@@ -61,4 +61,11 @@ public class JobPartTrackerImpl implements JobPartTracker {
             tracker.removeObjectCompletedListener(listener);
         }
     }
+
+    @Override
+    public String toString() {
+        return "JobPartTrackerImpl{" +
+                "trackers=" + trackers.keySet() +
+                '}';
+    }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobState.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobState.java
@@ -108,4 +108,12 @@ class JobState implements AutoCloseable {
     public SeekableByteChannel getChannel(final String name, final long offset, final long length) {
         return this.channelCache.get(name).get(offset, length);
     }
+
+    @Override
+    public String toString() {
+        return "JobState{" +
+                "objectsRemaining=" + objectsRemaining +
+                ", partTracker=" + partTracker +
+                '}';
+    }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/WriteJobImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/WriteJobImpl.java
@@ -142,13 +142,16 @@ class WriteJobImpl extends JobImpl {
                     + ((this.getJobId() == null) ? "" : " " + this.getJobId().toString()));
             return;
         }
+
+        final int numTimesToRetry = 3;
+
         try (final JobState jobState = new JobState(
                 channelBuilder,
                 filteredChunks,
                 partTracker,
                 ImmutableMap.<String, ImmutableMultimap<BulkObject,Range>>of())) {
             final ChunkTransferrer chunkTransferrer = new ChunkTransferrer(
-                new PutObjectTransferrerRetryDecorator(jobState),
+                new PutObjectTransferrerRetryDecorator(jobState, numTimesToRetry),
                 this.client,
                 jobState.getPartTracker(),
                 this.maxParallelRequests

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/WriteJobImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/WriteJobImpl.java
@@ -143,13 +143,12 @@ class WriteJobImpl extends JobImpl {
             return;
         }
 
-        final int numTimesToRetry = 3;
-
         try (final JobState jobState = new JobState(
                 channelBuilder,
                 filteredChunks,
                 partTracker,
                 ImmutableMap.<String, ImmutableMultimap<BulkObject,Range>>of())) {
+            final int numTimesToRetry = 3;
             final ChunkTransferrer chunkTransferrer = new ChunkTransferrer(
                 new PutObjectTransferrerRetryDecorator(jobState, numTimesToRetry),
                 this.client,

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/WriteJobImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/WriteJobImpl.java
@@ -242,12 +242,12 @@ class WriteJobImpl extends JobImpl {
     }
 
     private final class PutObjectTransferrerRetryDecorator implements ItemTransferrer {
-        private static final int NUM_TIMES_TO_RETRY = 3;
-
         private final PutObjectTransferrer putObjectTransferrer;
+        private final int numTimesToRetry;
 
-        private PutObjectTransferrerRetryDecorator(final JobState jobState) {
+        private PutObjectTransferrerRetryDecorator(final JobState jobState, final int numTimesToRetry) {
             putObjectTransferrer = new PutObjectTransferrer(jobState);
+            this.numTimesToRetry = numTimesToRetry;
         }
 
         @Override
@@ -259,7 +259,7 @@ class WriteJobImpl extends JobImpl {
                     putObjectTransferrer.transferItem(client, ds3Object);
                     break;
                 } catch (final Throwable t) {
-                    if (ExceptionClassifier.isUnrecoverableException(t) || ++numRetries >= NUM_TIMES_TO_RETRY) {
+                    if (ExceptionClassifier.isUnrecoverableException(t) || ++numRetries >= numTimesToRetry) {
                         throw t;
                     }
                 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/WriteJobImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/WriteJobImpl.java
@@ -148,7 +148,7 @@ class WriteJobImpl extends JobImpl {
                 partTracker,
                 ImmutableMap.<String, ImmutableMultimap<BulkObject,Range>>of())) {
             final ChunkTransferrer chunkTransferrer = new ChunkTransferrer(
-                new PutObjectTransferrer(jobState),
+                new PutObjectTransferrerRetryDecorator(jobState),
                 this.client,
                 jobState.getPartTracker(),
                 this.maxParallelRequests
@@ -236,6 +236,32 @@ class WriteJobImpl extends JobImpl {
             }
         }
         return filtered;
+    }
+
+    private final class PutObjectTransferrerRetryDecorator implements ItemTransferrer {
+        private static final int NUM_TIMES_TO_RETRY = 3;
+
+        private final PutObjectTransferrer putObjectTransferrer;
+
+        private PutObjectTransferrerRetryDecorator(final JobState jobState) {
+            putObjectTransferrer = new PutObjectTransferrer(jobState);
+        }
+
+        @Override
+        public void transferItem(final Ds3Client client, final BulkObject ds3Object) throws IOException {
+            int numRetries = 0;
+
+            while(true) {
+                try {
+                    putObjectTransferrer.transferItem(client, ds3Object);
+                    break;
+                } catch (final Throwable t) {
+                    if (ExceptionClassifier.isUnrecoverableException(t) || ++numRetries >= NUM_TIMES_TO_RETRY) {
+                        throw t;
+                    }
+                }
+            }
+        }
     }
 
     private final class PutObjectTransferrer implements ItemTransferrer {


### PR DESCRIPTION
This adds a decorator to WriteJobImpl.transfer to enable retrying failed object puts. The PutJobManagement_Test class has a testWriteJobWithRetries that will fail once with a mocked Ds3ClientImpl and may fail again if you point the integration test at an http proxy that can inject errors. See https://github.com/GraciesPadre/test-proxy. Setting the environment variable DS3_ENDPOINT to something like http://192.168.6.156:9080 (a docker container running the http proxy) will cause the test to test to fail a second time due to the proxy failing the put object request the first time it's seen. It is not necessary to run the http proxy if you don't want to; the integration test will verify retry behavior by using the mocked Ds3ClientImpl.