### PR TITLE
Put object retries

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+    sdk_proxy:
+        image: spectralogic/sdk_proxy:latest
+        environment:
+            - DS3_TARGET_SYSTEM_DNS_NAME
+            - HTTP_PROXY_PORT
+            - HTTP_PROXY_ADMIN_PORT
+        ports:
+            - "9080:9080"
+            - "9090:9090"
+    ds3_jsdk_docker_test:
+        image: denverm80/ds3_jsdk_docker_test:latest
+        environment:
+            - DS3_ENDPOINT
+            - DS3_SECRET_KEY
+            - DS3_ACCESS_KEY
+            - GIT_REPO
+            - GIT_BRANCH
+        dns: 
+            - 10.1.0.9
+
+
+

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -21,3 +21,6 @@ echo "cd ds3_java_sdk"
 cd ds3_java_sdk
 
 ./gradlew test
+
+curl -X PUT http://localhost:${HTTP_PROXY_ADMIN_PORT}/close >/dev/null 2>&1
+

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpers.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpers.java
@@ -93,8 +93,27 @@ public abstract class Ds3ClientHelpers {
         return new Ds3ClientHelpersImpl(client);
     }
 
+    /**
+     * Wraps the given {@link com.spectralogic.ds3client.Ds3ClientImpl} with helper methods.
+     * @param client An instance of {@link com.spectralogic.ds3client.Ds3Client}, usually gotten from a callto
+     *               {@link com.spectralogic.ds3client.Ds3ClientBuilder}
+     * @param retryAfter The number of times to attempt to allocate a chunk before giving up.
+     * @return An instance of {@link com.spectralogic.ds3client.Ds3Client} wrapped with helper methods.
+     */
     public static Ds3ClientHelpers wrap(final Ds3Client client, final int retryAfter) {
         return new Ds3ClientHelpersImpl(client, retryAfter);
+    }
+
+    /**
+     * Wraps the given {@link com.spectralogic.ds3client.Ds3ClientImpl} with helper methods.
+     * @param client An instance of {@link com.spectralogic.ds3client.Ds3Client}, usually gotten from a callto
+     *               {@link com.spectralogic.ds3client.Ds3ClientBuilder}
+     * @param retryAfter The number of times to attempt to allocate a chunk before giving up.
+     * @param objectTransferAttempts The number of times to attempt to transfer an object before giving up.
+     * @return An instance of {@link com.spectralogic.ds3client.Ds3Client} wrapped with helper methods.
+     */
+    public static Ds3ClientHelpers wrap(final Ds3Client client, final int retryAfter, final int objectTransferAttempts) {
+        return new Ds3ClientHelpersImpl(client, retryAfter, objectTransferAttempts);
     }
 
     /**

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpersImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpersImpl.java
@@ -50,17 +50,24 @@ class Ds3ClientHelpersImpl extends Ds3ClientHelpers {
 
     private final static Logger LOG = LoggerFactory.getLogger(Ds3ClientHelpersImpl.class);
     private final static int DEFAULT_LIST_OBJECTS_RETRIES = 5;
+    private final static int DEFAULT_OBJECT_TRANSFER_ATTEMPTS = 5;
 
     private final Ds3Client client;
     private final int retryAfter;
+    private final int objectTransferAttempts;
 
     public Ds3ClientHelpersImpl(final Ds3Client client) {
         this(client, -1);
     }
 
     public Ds3ClientHelpersImpl(final Ds3Client client, final int retryAfter) {
+        this(client, retryAfter, DEFAULT_OBJECT_TRANSFER_ATTEMPTS);
+    }
+
+    public Ds3ClientHelpersImpl(final Ds3Client client, final int retryAfter, final int objectTransferAttempts) {
         this.client = client;
         this.retryAfter = retryAfter;
+        this.objectTransferAttempts = objectTransferAttempts;
     }
 
     @Override
@@ -90,7 +97,12 @@ class Ds3ClientHelpersImpl extends Ds3ClientHelpers {
                 .withMaxUploadSize(options.getMaxUploadSize())
                 .withAggregating(options.isAggregating())
                 .withIgnoreNamingConflicts(options.doIgnoreNamingConflicts()));
-        return new WriteJobImpl(this.client, prime.getResult(), this.retryAfter, options.getChecksumType());
+        return new WriteJobImpl(
+                this.client,
+                prime.getResult(),
+                this.retryAfter,
+                options.getChecksumType(),
+                this.objectTransferAttempts);
     }
 
     @Override
@@ -157,7 +169,8 @@ class Ds3ClientHelpersImpl extends Ds3ClientHelpers {
                 this.client,
                 jobResponse.getMasterObjectListResult(),
                 this.retryAfter,
-                ChecksumType.Type.NONE);
+                ChecksumType.Type.NONE,
+                this.objectTransferAttempts);
     }
 
     @Override

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/ExceptionClassifier.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/ExceptionClassifier.java
@@ -1,0 +1,30 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.helpers;
+
+import java.io.IOException;
+
+public final class ExceptionClassifier {
+    private ExceptionClassifier() { }
+
+    public static boolean isRecoverableException(final Throwable t) {
+        return t instanceof IOException;
+    }
+
+    public static boolean isUnrecoverableException(final Throwable t) {
+        return ! isRecoverableException(t);
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobPartTrackerImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobPartTrackerImpl.java
@@ -61,4 +61,11 @@ public class JobPartTrackerImpl implements JobPartTracker {
             tracker.removeObjectCompletedListener(listener);
         }
     }
+
+    @Override
+    public String toString() {
+        return "JobPartTrackerImpl{" +
+                "trackers=" + trackers.keySet() +
+                '}';
+    }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobState.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobState.java
@@ -108,4 +108,12 @@ class JobState implements AutoCloseable {
     public SeekableByteChannel getChannel(final String name, final long offset, final long length) {
         return this.channelCache.get(name).get(offset, length);
     }
+
+    @Override
+    public String toString() {
+        return "JobState{" +
+                "objectsRemaining=" + objectsRemaining +
+                ", partTracker=" + partTracker +
+                '}';
+    }
 }


### PR DESCRIPTION
This adds a decorator to WriteJobImpl.transfer to enable retrying failed object puts. The PutJobManagement_Test class has a testWriteJobWithRetries that will fail once with a mocked Ds3ClientImpl and may fail again if you point the integration test at an http proxy that can inject errors. See https://github.com/GraciesPadre/test-proxy. Setting the environment variable DS3_ENDPOINT to something like http://192.168.6.156:9080 (a docker container running the http proxy) will cause the test to test to fail a second time due to the proxy failing the put object request the first time it's seen. It is not necessary to run the http proxy if you don't want to; the integration test will verify retry behavior by using the mocked Ds3ClientImpl.