### PR TITLE
No longer need to shut the http proxy down from the run-tests script, because the jenkins job does so.

### DIFF
--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -22,5 +22,3 @@ cd ds3_java_sdk
 
 ./gradlew test
 
-curl -X PUT http://localhost:${HTTP_PROXY_ADMIN_PORT}/close >/dev/null 2>&1
-


### PR DESCRIPTION
Taking the shutdown out prevents the docker shell from reporting an error.