### PR TITLE
Missed one spot 

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/WriteJobImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/WriteJobImpl.java
@@ -170,7 +170,6 @@ class WriteJobImpl extends JobImpl {
                 throw new RuntimeException(e);
             }
         } catch (final Throwable t) {
-            running = false;
             emitFailureEvent(makeFailureEvent(FailureEvent.FailureActivity.PuttingObject, t, masterObjectList.getObjects().get(0)));
             throw t;
         }


### PR DESCRIPTION
when removing a misguided attempt to take a job out of running state.