### PR TITLE
Added request id to failed request exception

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/FailedRequestException.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/FailedRequestException.java
@@ -87,7 +87,7 @@ public class FailedRequestException extends IOException {
         return requestId;
     }
     
-    private static String buildExceptionMessage(final Error error,
+    protected static String buildExceptionMessage(final Error error,
                                                 final ImmutableList<Integer> expectedStatusCodes,
                                                 final int statusCode,
                                                 final String requestId) {
@@ -104,8 +104,8 @@ public class FailedRequestException extends IOException {
                 "Expected a status code of %s but got %d %s. Error message: \"%s\"",
                 joiner.join(expectedStatusCodes),
                 statusCode,
-                error.getMessage(),
-                buildRequestIdMessage(requestId)
+                buildRequestIdMessage(requestId),
+                error.getMessage()
             );
     }
 
@@ -113,7 +113,7 @@ public class FailedRequestException extends IOException {
      * Creates the request-ID portion of the exception message. The message specifies the
      * request-ID if requestId is non-null, else it specifies an unknown request.
      */
-    private static String buildRequestIdMessage(final String requestId) {
+    protected static String buildRequestIdMessage(final String requestId) {
         if (Guard.isStringNullOrEmpty(requestId)) {
             return "for unknown request";
         }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/FailedRequestException.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/FailedRequestException.java
@@ -18,6 +18,7 @@ package com.spectralogic.ds3client.networking;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3client.models.Error;
+import com.spectralogic.ds3client.utils.Guard;
 
 import java.io.IOException;
 import java.util.List;
@@ -29,12 +30,14 @@ public class FailedRequestException extends IOException {
     private final ImmutableList<Integer> expectedStatusCodes;
     private final Error error;
     private final String responseString;
+    private final String requestId;
 
     public FailedRequestException(final int[] expectedStatusCodes,
                                   final int statusCode,
                                   final Error error,
-                                  final String responseString) {
-        this(toList(expectedStatusCodes), statusCode, error, responseString);
+                                  final String responseString,
+                                  final String requestId) {
+        this(toList(expectedStatusCodes), statusCode, error, responseString, requestId);
     }
 
     private static ImmutableList<Integer> toList(final int[] expectedStatusCodes) {
@@ -49,12 +52,14 @@ public class FailedRequestException extends IOException {
     public FailedRequestException(final ImmutableList<Integer> expectedStatusCodes,
                                   final int statusCode,
                                   final Error error,
-                                  final String responseString) {
-        super(buildExceptionMessage(error, expectedStatusCodes, statusCode));
+                                  final String responseString,
+                                  final String requestId) {
+        super(buildExceptionMessage(error, expectedStatusCodes, statusCode, requestId));
         this.statusCode = statusCode;
         this.expectedStatusCodes = expectedStatusCodes;
         this.error = error;
         this.responseString = responseString;
+        this.requestId = requestId;
     }
 
     public int getStatusCode() {
@@ -73,27 +78,46 @@ public class FailedRequestException extends IOException {
     public Error getError() {
         return error;
     }
+
     public String getResponseString() {
         return responseString;
+    }
+
+    public String getRequestId() {
+        return requestId;
     }
     
     private static String buildExceptionMessage(final Error error,
                                                 final ImmutableList<Integer> expectedStatusCodes,
-                                                final int statusCode) {
+                                                final int statusCode,
+                                                final String requestId) {
 
         final Joiner joiner = Joiner.on(", ");
         return error == null
             ? String.format(
-                "Expected a status code of %s but got %d. Could not parse the response for additional information.",
-                joiner.join(expectedStatusCodes),
-                statusCode
-            )
-            : String.format(
-                "Expected a status code of %s but got %d. Error message: \"%s\"",
+                "Expected a status code of %s but got %d %s. Could not parse the response for additional information.",
                 joiner.join(expectedStatusCodes),
                 statusCode,
-                error.getMessage()
+                buildRequestIdMessage(requestId)
+            )
+            : String.format(
+                "Expected a status code of %s but got %d %s. Error message: \"%s\"",
+                joiner.join(expectedStatusCodes),
+                statusCode,
+                error.getMessage(),
+                buildRequestIdMessage(requestId)
             );
+    }
+
+    /**
+     * Creates the request-ID portion of the exception message. The message specifies the
+     * request-ID if requestId is non-null, else it specifies an unknown request.
+     */
+    private static String buildRequestIdMessage(final String requestId) {
+        if (Guard.isStringNullOrEmpty(requestId)) {
+            return "for unknown request";
+        }
+        return "for request #" + requestId;
     }
 
     @Override

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/FailedRequestUsingMgmtPortException.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/FailedRequestUsingMgmtPortException.java
@@ -15,12 +15,8 @@
 
 package com.spectralogic.ds3client.networking;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3client.models.Error;
-
-import java.io.IOException;
-import java.util.List;
 
 public class  FailedRequestUsingMgmtPortException extends  FailedRequestException {
 
@@ -28,8 +24,8 @@ public class  FailedRequestUsingMgmtPortException extends  FailedRequestExceptio
     public final static String MGMT_PORT_HEADER = "Spectra-Data-Path-Request-Made-On-Management-Path";
     public final static String MGMT_PORT_RESPONSE = "REST (data) request made on management port";
 
-    public FailedRequestUsingMgmtPortException(final ImmutableList<Integer> expectedStatusCodes) {
-        super(expectedStatusCodes, MGMT_PORT_STATUS_CODE, new Error(), MGMT_PORT_RESPONSE);
+    public FailedRequestUsingMgmtPortException(final ImmutableList<Integer> expectedStatusCodes, final String requestId) {
+        super(expectedStatusCodes, MGMT_PORT_STATUS_CODE, new Error(), MGMT_PORT_RESPONSE, requestId);
     }
 
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/HeadersImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/HeadersImpl.java
@@ -16,7 +16,6 @@
 package com.spectralogic.ds3client.networking;
 
 import com.google.common.collect.ImmutableMultimap;
-import com.spectralogic.ds3client.networking.Headers;
 import org.apache.http.Header;
 
 import java.util.List;

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/commands/parsers/utils/ResponseParserUtils_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/commands/parsers/utils/ResponseParserUtils_Test.java
@@ -1,0 +1,53 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.commands.parsers.utils;
+
+import com.google.common.collect.ImmutableMap;
+import com.spectralogic.ds3client.MockedHeaders;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ResponseParserUtils_Test {
+
+    @Test
+    public void getRequestId_Test() {
+        final String requestId = "123";
+        final ImmutableMap<String, String> headers = ImmutableMap.of(
+                "x-amz-request-id", requestId,
+                "Content-Type", "Text/xml");
+
+        final String result = ResponseParserUtils.getRequestId(new MockedHeaders(headers));
+        assertThat(result, is(requestId));
+    }
+
+    @Test
+    public void getRequestId_WithoutRequestId_Test() {
+        final ImmutableMap<String, String> headers = ImmutableMap.of(
+                "Content-Type", "Text/xml");
+
+        final String result = ResponseParserUtils.getRequestId(new MockedHeaders(headers));
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void getRequestId_EmptyHeaders_Test() {
+        final String result = ResponseParserUtils.getRequestId(new MockedHeaders(ImmutableMap.<String, String>of()));
+        assertThat(result, is(nullValue()));
+    }
+}

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpers_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpers_Test.java
@@ -657,7 +657,7 @@ public class Ds3ClientHelpers_Test {
         final HeadBucketResponse response = buildHeadBucketResponse(HeadBucketResponse.Status.DOESNTEXIST);
         Mockito.when(ds3Client.headBucket(Mockito.any(HeadBucketRequest.class))).thenReturn(response);
         Mockito.when(ds3Client.putBucket(Mockito.any(PutBucketRequest.class)))
-                .thenThrow(new FailedRequestException(ImmutableList.of(202, 409), 409, new Error(), "Conflict"));
+                .thenThrow(new FailedRequestException(ImmutableList.of(202, 409), 409, new Error(), "Conflict", "5"));
 
         final Ds3ClientHelpers helpers = Ds3ClientHelpers.wrap(ds3Client);
 
@@ -671,7 +671,7 @@ public class Ds3ClientHelpers_Test {
         final HeadBucketResponse response = buildHeadBucketResponse(HeadBucketResponse.Status.DOESNTEXIST);
         Mockito.when(ds3Client.headBucket(Mockito.any(HeadBucketRequest.class))).thenReturn(response);
         Mockito.when(ds3Client.putBucket(Mockito.any(PutBucketRequest.class)))
-                .thenThrow(new FailedRequestException(ImmutableList.of(202, 409, 500), 500, new Error(), "Error"));
+                .thenThrow(new FailedRequestException(ImmutableList.of(202, 409, 500), 500, new Error(), "Error", "5"));
 
         final Ds3ClientHelpers helpers = Ds3ClientHelpers.wrap(ds3Client);
 

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/networking/FailedRequestException_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/networking/FailedRequestException_Test.java
@@ -16,15 +16,12 @@
 package com.spectralogic.ds3client.networking;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.spectralogic.ds3client.MockedHeaders;
-import com.spectralogic.ds3client.models.*;
 import com.spectralogic.ds3client.models.Error;
 import org.junit.Test;
 
-import static com.spectralogic.ds3client.networking.FailedRequestException.*;
+import static com.spectralogic.ds3client.networking.FailedRequestException.buildExceptionMessage;
+import static com.spectralogic.ds3client.networking.FailedRequestException.buildRequestIdMessage;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FailedRequestException_Test {

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/networking/FailedRequestException_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/networking/FailedRequestException_Test.java
@@ -1,0 +1,83 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.networking;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.spectralogic.ds3client.MockedHeaders;
+import com.spectralogic.ds3client.models.*;
+import com.spectralogic.ds3client.models.Error;
+import org.junit.Test;
+
+import static com.spectralogic.ds3client.networking.FailedRequestException.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FailedRequestException_Test {
+
+    private static Error createTestError() {
+        final Error error = new Error();
+        error.setMessage("Error message");
+        return error;
+    }
+
+    @Test
+    public void buildRequestIdMessage_Test() {
+        final String result = buildRequestIdMessage("123");
+        assertThat(result, is("for request #123"));
+    }
+
+    @Test
+    public void buildRequestIdMessage_EmptyId_Test() {
+        final String result = buildRequestIdMessage("");
+        assertThat(result, is("for unknown request"));
+    }
+
+    @Test
+    public void buildRequestIdMessage_NullId_Test() {
+        final String result = buildRequestIdMessage(null);
+        assertThat(result, is("for unknown request"));
+    }
+
+    @Test
+    public void buildExceptionMessage_NullErrorAndRequestId_Test() {
+        final String expected = "Expected a status code of 200, 203 but got 400 for unknown request. Could not parse the response for additional information.";
+        final String result = buildExceptionMessage(null, ImmutableList.of(200, 203), 400, null);
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void buildExceptionMessage_NullError_Test() {
+        final String expected = "Expected a status code of 200, 203 but got 400 for request #123. Could not parse the response for additional information.";
+        final String result = buildExceptionMessage(null, ImmutableList.of(200, 203), 400, "123");
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void buildExceptionMessage_NullRequestId_Test() {
+        final String expected = "Expected a status code of 200, 203 but got 400 for unknown request. Error message: \"Error message\"";
+        final String result = buildExceptionMessage(createTestError(), ImmutableList.of(200, 203), 400, null);
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void buildExceptionMessage_Test() {
+        final String expected = "Expected a status code of 200, 203 but got 400 for request #123. Error message: \"Error message\"";
+        final String result = buildExceptionMessage(createTestError(), ImmutableList.of(200, 203), 400, "123");
+        assertThat(result, is(expected));
+    }
+}


### PR DESCRIPTION
**Changes**
- Retrieves request-id from response headers in failing request exception
- Adds request-id to exception message
- Created unit tests for new util function `getRequestId` that retrieves the `x-amz-request-id` from the web response headers