### PR TITLE
Removed old reference to getStatusCode

### DIFF
--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/Regression_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/Regression_Test.java
@@ -298,7 +298,6 @@ public class Regression_Test {
                     0,
                     Files.size(objPath1)));
             assertThat(putResponse1, is(notNullValue()));
-            assertThat(putResponse1.getStatusCode(), is(equalTo(200)));
 
             // Interuption...
             final Ds3ClientHelpers.Job recoverJob = HELPERS.recoverWriteJob(job.getJobId());


### PR DESCRIPTION
**Change**
The merge of `master` with `3_2_2_autogen` left a reference to `getStatusCode`, which now causes a compilation error.  Therefore, this line was removed from the test.