### PR TITLE
DO NOT MERGE - looking for feedback on initial diagnostics implementation

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3DiagnosticSummary.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3DiagnosticSummary.java
@@ -1,0 +1,26 @@
+/*
+ * ****************************************************************************
+ *    Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *    Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *    this file except in compliance with the License. A copy of the License is located at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file.
+ *    This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *    specific language governing permissions and limitations under the License.
+ *  ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.diagnostics;
+
+/**
+ * An enum representing all of the runnable diagnostics. This is used
+ * in the {@link Ds3DiagnosticsResult#getSummary()} to denote which
+ * diagnostics returned a possible issue.
+ */
+public enum Ds3DiagnosticSummary {
+    CACHE_NEAR_CAPACITY,
+    OFFLINE_TAPES
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3Diagnostics.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3Diagnostics.java
@@ -1,0 +1,44 @@
+/*
+ * ****************************************************************************
+ *    Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *    Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *    this file except in compliance with the License. A copy of the License is located at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file.
+ *    This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *    specific language governing permissions and limitations under the License.
+ *  ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.diagnostics;
+
+import com.spectralogic.ds3client.Ds3Client;
+import com.spectralogic.ds3client.models.Tape;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A wrapper around the {@link com.spectralogic.ds3client.Ds3Client} which performs diagnostics.
+ */
+public abstract class Ds3Diagnostics {
+
+    /**
+     * Wraps the given {@link com.spectralogic.ds3client.Ds3ClientImpl} with diagnostics methods.
+     * @param client An instance of {@link com.spectralogic.ds3client.Ds3Client}, usually gotten from a call to
+     *               {@link com.spectralogic.ds3client.Ds3ClientBuilder}
+     * @return An instance of {@link com.spectralogic.ds3client.Ds3Client} wrapped with diagnostics methods.
+     */
+    public static Ds3Diagnostics wrap(final Ds3Client client) {
+        return new Ds3DiagnosticsImpl(client);
+    }
+
+    //TODO test and comment
+    public abstract void checkCacheAvailability() throws IOException;
+
+    //TODO test and comment
+    public abstract List<Tape> getOfflineTapes() throws IOException;
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3Diagnostics.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3Diagnostics.java
@@ -15,16 +15,21 @@
 
 package com.spectralogic.ds3client.diagnostics;
 
+import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3client.Ds3Client;
+import com.spectralogic.ds3client.models.CacheFilesystemInformation;
 import com.spectralogic.ds3client.models.Tape;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Optional;
 
 /**
  * A wrapper around the {@link com.spectralogic.ds3client.Ds3Client} which performs diagnostics.
  */
 public abstract class Ds3Diagnostics {
+
+    /** The amount of file cache utilization that is considered near capacity */
+    protected static final double CACHE_UTILIZATION_NEAR_CAPACITY_LEVEL = 0.95;
 
     /**
      * Wraps the given {@link com.spectralogic.ds3client.Ds3ClientImpl} with diagnostics methods.
@@ -36,9 +41,28 @@ public abstract class Ds3Diagnostics {
         return new Ds3DiagnosticsImpl(client);
     }
 
-    //TODO test and comment
-    public abstract void checkCacheAvailability() throws IOException;
+    /**
+     * Retrieves the {@link CacheFilesystemInformation} for all cache that are near capacity.
+     * A cache is determined near capacity if the current utilization is at or exceeds
+     * {@link #CACHE_UTILIZATION_NEAR_CAPACITY_LEVEL}. If no file systems are near capacity,
+     * than an empty {@link Optional} is returned.
+     * @throws com.spectralogic.ds3client.exceptions.NoCacheFileSystemException If no cache file systems are found
+     * @throws IOException
+     */
+    public abstract Optional<ImmutableList<CacheFilesystemInformation>> getCacheNearCapacity() throws IOException;
 
-    //TODO test and comment
-    public abstract List<Tape> getOfflineTapes() throws IOException;
+    /**
+     * Retrieves the {@link Tape} for all tapes with status of OFFLINE. If no tapes are offline,
+     * than an empty {@link Optional} is returned.
+     * @throws IOException
+     */
+    public abstract Optional<ImmutableList<Tape>> getOfflineTapes() throws IOException;
+
+    /**
+     * Runs all diagnostics and returns the combined result of:
+     *   {@link #getCacheNearCapacity()},
+     *   {@link #getOfflineTapes()}
+     * @throws IOException
+     */
+    public abstract Ds3DiagnosticsResult runDiagnostics() throws IOException;
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3DiagnosticsEmptyResult.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3DiagnosticsEmptyResult.java
@@ -1,0 +1,44 @@
+/*
+ * ****************************************************************************
+ *    Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *    Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *    this file except in compliance with the License. A copy of the License is located at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file.
+ *    This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *    specific language governing permissions and limitations under the License.
+ *  ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.diagnostics;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3client.models.CacheFilesystemInformation;
+import com.spectralogic.ds3client.models.Tape;
+
+import java.util.Optional;
+
+/**
+ * An empty result for running diagnostics. This is returned in the
+ * instance that no potential issues were detected.
+ */
+public class Ds3DiagnosticsEmptyResult implements Ds3DiagnosticsResult {
+
+    @Override
+    public Optional<ImmutableList<Ds3DiagnosticSummary>> getSummary() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ImmutableList<CacheFilesystemInformation>> getCacheNearCapacity() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ImmutableList<Tape>> getOfflineTapes() {
+        return Optional.empty();
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3DiagnosticsFullResult.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3DiagnosticsFullResult.java
@@ -1,0 +1,61 @@
+/*
+ * ****************************************************************************
+ *    Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *    Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *    this file except in compliance with the License. A copy of the License is located at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file.
+ *    This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *    specific language governing permissions and limitations under the License.
+ *  ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.diagnostics;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3client.models.CacheFilesystemInformation;
+import com.spectralogic.ds3client.models.Tape;
+
+import java.util.Optional;
+
+/**
+ * Contains the result of running all diagnostic in {@link Ds3Diagnostics#runDiagnostics()}
+ */
+public class Ds3DiagnosticsFullResult implements Ds3DiagnosticsResult {
+
+    /**
+     * Contains a list of {@link Ds3DiagnosticSummary} which acts as a summary
+     * for which diagnostics reported potential issues
+     * */
+    private final Optional<ImmutableList<Ds3DiagnosticSummary>> summary;
+
+    /** Contains the result of {@link Ds3Diagnostics#getCacheNearCapacity()} */
+    private final Optional<ImmutableList<CacheFilesystemInformation>> cacheNearCapacity;
+
+    /** Contains the result of {@link Ds3Diagnostics#getOfflineTapes()} */
+    private final Optional<ImmutableList<Tape>> offlineTapes;
+
+    public Ds3DiagnosticsFullResult(
+            final Optional<ImmutableList<CacheFilesystemInformation>> cacheNearCapacity,
+            final Optional<ImmutableList<Tape>> offlineTapes,
+            Optional<ImmutableList<Ds3DiagnosticSummary>> summary) {
+        this.cacheNearCapacity = cacheNearCapacity;
+        this.offlineTapes = offlineTapes;
+        this.summary = summary;
+    }
+
+    public Optional<ImmutableList<CacheFilesystemInformation>> getCacheNearCapacity() {
+        return cacheNearCapacity;
+    }
+
+    public Optional<ImmutableList<Tape>> getOfflineTapes() {
+        return offlineTapes;
+    }
+
+    public Optional<ImmutableList<Ds3DiagnosticSummary>> getSummary() {
+        return summary;
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3DiagnosticsImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3DiagnosticsImpl.java
@@ -1,0 +1,87 @@
+/*
+ * ****************************************************************************
+ *    Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *    Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *    this file except in compliance with the License. A copy of the License is located at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file.
+ *    This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *    specific language governing permissions and limitations under the License.
+ *  ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.diagnostics;
+
+import com.spectralogic.ds3client.Ds3Client;
+import com.spectralogic.ds3client.commands.spectrads3.*;
+import com.spectralogic.ds3client.models.CacheFilesystemInformation;
+import com.spectralogic.ds3client.models.Tape;
+import com.spectralogic.ds3client.models.TapeState;
+import com.spectralogic.ds3client.utils.Guard;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+public class Ds3DiagnosticsImpl extends Ds3Diagnostics {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Ds3DiagnosticsImpl.class);
+
+    /** The amount of file cache utilization that triggers a warning */
+    private static final double CACHE_UTILIZATION_WARNING_LEVEL = 0.95;
+
+    private final Ds3Client client;
+
+    public Ds3DiagnosticsImpl(final Ds3Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public void checkCacheAvailability() throws IOException {
+        final GetCacheStateSpectraS3Response response = client
+                .getCacheStateSpectraS3(new GetCacheStateSpectraS3Request());
+        final List<CacheFilesystemInformation> fileSystemsInfo = response.getCacheInformationResult().getFilesystems();
+        if (Guard.isNullOrEmpty(fileSystemsInfo)) {
+            LOG.error("There are no cache file systems");
+            return;
+        }
+        for (final CacheFilesystemInformation fileSystemInfo : fileSystemsInfo) {
+            final UUID fileSystemId = fileSystemInfo.getCacheFilesystem().getId();
+            final long availableCapacity = fileSystemInfo.getAvailableCapacityInBytes();
+            final long usedCapacity = fileSystemInfo.getUsedCapacityInBytes();
+            final double percentUtilization = usedCapacity / availableCapacity;
+            LOG.info("Cache file system {}: {} bytes available capacity, {} bytes used capacity, {}% currently utilized",
+                    fileSystemId.toString(),
+                    availableCapacity,
+                    usedCapacity,
+                    percentUtilization);
+
+            if (percentUtilization >= CACHE_UTILIZATION_WARNING_LEVEL) {
+                LOG.warn("Cache file system {} is near full with {}% currently utilized",
+                        fileSystemId,
+                        percentUtilization);
+            }
+        }
+    }
+
+    @Override
+    @Nullable
+    public List<Tape> getOfflineTapes() throws IOException {
+        final GetTapesSpectraS3Request getTapesRequest = new GetTapesSpectraS3Request().withState(TapeState.OFFLINE);
+        final GetTapesSpectraS3Response getTapesResponse = client.getTapesSpectraS3(getTapesRequest);
+        final List<Tape> offlineTapes = getTapesResponse.getTapeListResult().getTapes();
+        if (Guard.isNullOrEmpty(offlineTapes)) {
+            LOG.info("There are no tapes with status = OFFLINE");
+        } else {
+            LOG.warn("There are {} tapes with status = OFFLINE", offlineTapes.size());
+        }
+        return offlineTapes;
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3DiagnosticsResult.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/diagnostics/Ds3DiagnosticsResult.java
@@ -1,0 +1,31 @@
+/*
+ * ****************************************************************************
+ *    Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *    Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *    this file except in compliance with the License. A copy of the License is located at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file.
+ *    This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *    specific language governing permissions and limitations under the License.
+ *  ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.diagnostics;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3client.models.CacheFilesystemInformation;
+import com.spectralogic.ds3client.models.Tape;
+
+import java.util.Optional;
+
+public interface Ds3DiagnosticsResult {
+
+    Optional<ImmutableList<Ds3DiagnosticSummary>> getSummary();
+
+    Optional<ImmutableList<CacheFilesystemInformation>> getCacheNearCapacity();
+
+    Optional<ImmutableList<Tape>> getOfflineTapes();
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/exceptions/NoCacheFileSystemException.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/exceptions/NoCacheFileSystemException.java
@@ -1,0 +1,29 @@
+/*
+ * ****************************************************************************
+ *    Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *    Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *    this file except in compliance with the License. A copy of the License is located at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file.
+ *    This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *    specific language governing permissions and limitations under the License.
+ *  ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.exceptions;
+
+import com.spectralogic.ds3client.commands.spectrads3.GetCacheStateSpectraS3Request;
+
+/**
+ * Denotes that no cache file systems were found with the command
+ * {@link com.spectralogic.ds3client.Ds3Client#getCacheStateSpectraS3(GetCacheStateSpectraS3Request)}
+ */
+public class NoCacheFileSystemException extends RuntimeException {
+
+    public NoCacheFileSystemException() {
+        super("No cache file systems were found");
+    }
+}


### PR DESCRIPTION
**Changes**
- Implemented Ds3Diagnostics as a wrapper for client
  - Each diagnostic is a separate function
  - `runDiagnostics` runs all diagnostics and combines the result in a `Ds3DiagnosticsResult` model
  - Limited implementation: currently only checks if the cache is close to full and if tapes are offline

**TODO**
- Write unit tests