### PR TITLE
Fix integration tests that broke with latest http proxy

### DIFF
--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/PutJobManagement_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/PutJobManagement_Test.java
@@ -837,7 +837,7 @@ public class PutJobManagement_Test {
 
         try {
             final String DIR_NAME = "largeFiles/";
-            final String[] FILE_NAMES = new String[]{"lesmis-copies.txt"};
+            final String[] FILE_NAMES = new String[]{"lesmis.txt"};
 
             final Path dirPath = ResourceUtils.loadFileResource(DIR_NAME);
 


### PR DESCRIPTION
An integration test broke when I introduced a change into the http proxy, where I injected a fault into the file lesmis-copies.txt.  Using a different file in this test is still valid, because we're using a ds3 client shim that also injects faults, which exercises the logic we're trying to validate with
this test -- retry logic.  I'll update this test when I get finished with the partial read retry stuff I'm working on, which is why I monkeyed with
the http proxy to begin with :(