### PR TITLE
Explicit check for active job before recovering job in helpers

### DIFF
--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/Smoke_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/Smoke_Test.java
@@ -701,7 +701,7 @@ public class Smoke_Test {
 
         } finally {
             deleteAllContents(client, bucketName);
-            for( final Path tempFile : Files.newDirectoryStream(dirPath) ){
+            for (final Path tempFile : Files.newDirectoryStream(dirPath) ){
                 Files.delete(tempFile);
             }
             Files.delete(dirPath);
@@ -756,7 +756,7 @@ public class Smoke_Test {
             assert false;
         } finally {
             deleteAllContents(client, bucketName);
-            for( final Path tempFile : Files.newDirectoryStream(dirPath) ){
+            for (final Path tempFile : Files.newDirectoryStream(dirPath) ){
                 Files.delete(tempFile);
             }
             Files.delete(dirPath);

--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/Smoke_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/Smoke_Test.java
@@ -24,6 +24,7 @@ import com.spectralogic.ds3client.commands.interfaces.BulkResponse;
 import com.spectralogic.ds3client.commands.spectrads3.*;
 import com.spectralogic.ds3client.helpers.Ds3ClientHelpers;
 import com.spectralogic.ds3client.helpers.JobRecoveryException;
+import com.spectralogic.ds3client.helpers.JobRecoveryNotActiveException;
 import com.spectralogic.ds3client.helpers.ObjectCompletedListener;
 import com.spectralogic.ds3client.helpers.options.WriteJobOptions;
 import com.spectralogic.ds3client.integration.test.helpers.JobStatusHelper;
@@ -484,6 +485,47 @@ public class Smoke_Test {
         }
     }
 
+    @Test (expected = JobRecoveryNotActiveException.class)
+    public void testRecoverWriteJobCanceledJob() throws IOException, URISyntaxException, JobRecoveryException {
+        final String bucketName = "test_canceled_recover_write_job_bucket";
+        final String book1 = "beowulf.txt";
+        final String book2 = "ulysses.txt";
+
+        try {
+            HELPERS.ensureBucketExists(bucketName, envDataPolicyId);
+
+            final Path objPath1 = ResourceUtils.loadFileResource(RESOURCE_BASE_NAME + book1);
+            final Path objPath2 = ResourceUtils.loadFileResource(RESOURCE_BASE_NAME + book2);
+            final Ds3Object obj1 = new Ds3Object(book1, Files.size(objPath1));
+            final Ds3Object obj2 = new Ds3Object(book2, Files.size(objPath2));
+
+            final Ds3ClientHelpers.Job job = Ds3ClientHelpers.wrap(client).startWriteJob(bucketName, Lists.newArrayList(obj1, obj2));
+
+            final PutObjectResponse putResponse1 = client.putObject(new PutObjectRequest(
+                    job.getBucketName(),
+                    book1,
+                    new ResourceObjectPutter(RESOURCE_BASE_NAME).buildChannel(book1),
+                    job.getJobId().toString(),
+                    0,
+                    Files.size(objPath1)));
+            assertThat(putResponse1, is(notNullValue()));
+
+            // Cancel write job and attempt recovery
+            client.cancelActiveJobSpectraS3(new CancelActiveJobSpectraS3Request(job.getJobId()));
+
+            // Attempt recovery of canceled job
+            HELPERS.recoverWriteJob(job.getJobId());
+            assert false;
+        } finally {
+            deleteAllContents(client, bucketName);
+        }
+    }
+
+    @Test (expected = JobRecoveryNotActiveException.class)
+    public void testRecoverWriteJobDoesNotExist() throws IOException, JobRecoveryException {
+        HELPERS.recoverWriteJob(UUID.randomUUID());
+    }
+
     @Test
     public void verifySendCrc32cChecksum() throws IOException, URISyntaxException {
         final String bucketName = "crc_32_bucket";
@@ -664,6 +706,66 @@ public class Smoke_Test {
             }
             Files.delete(dirPath);
         }
+    }
+
+    @Test (expected = JobRecoveryNotActiveException.class)
+    public void testRecoverReadJobCanceledJob() throws IOException, JobRecoveryException, URISyntaxException {
+        final String bucketName = "test_canceled_recover_read_job_bucket";
+        final String book1 = "beowulf.txt";
+        final String book2 = "ulysses.txt";
+        final Path objPath1 = ResourceUtils.loadFileResource(RESOURCE_BASE_NAME + book1);
+        final Path objPath2 = ResourceUtils.loadFileResource(RESOURCE_BASE_NAME + book2);
+        final Ds3Object obj1 = new Ds3Object(book1, Files.size(objPath1));
+        final Ds3Object obj2 = new Ds3Object(book2, Files.size(objPath2));
+
+        final Path dirPath = FileSystems.getDefault().getPath("output_canceled_job");
+        if (!Files.exists(dirPath)) {
+            Files.createDirectory(dirPath);
+        }
+
+        try {
+            HELPERS.ensureBucketExists(bucketName, envDataPolicyId);
+
+            final Ds3ClientHelpers.Job putJob = HELPERS.startWriteJob(bucketName, Lists.newArrayList(obj1, obj2));
+            putJob.transfer(new ResourceObjectPutter(RESOURCE_BASE_NAME));
+
+            final FileChannel channel1 = FileChannel.open(
+                    dirPath.resolve(book1),
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING
+            );
+
+            final Ds3ClientHelpers.Job readJob = HELPERS.startReadJob(bucketName, Lists.newArrayList(obj1, obj2));
+            final GetObjectResponse readResponse1 = client.getObject(
+                    new GetObjectRequest(
+                            bucketName,
+                            book1,
+                            channel1,
+                            readJob.getJobId().toString(),
+                            0));
+
+            assertThat(readResponse1, is(notNullValue()));
+            assertThat(readResponse1.getObjectSize(), is(notNullValue()));
+
+            // Cancel active job
+            client.cancelActiveJobSpectraS3(new CancelActiveJobSpectraS3Request(readJob.getJobId()));
+
+            // Attempt recovery of canceled job
+            HELPERS.recoverReadJob(readJob.getJobId());
+            assert false;
+        } finally {
+            deleteAllContents(client, bucketName);
+            for( final Path tempFile : Files.newDirectoryStream(dirPath) ){
+                Files.delete(tempFile);
+            }
+            Files.delete(dirPath);
+        }
+    }
+
+    @Test (expected = JobRecoveryNotActiveException.class)
+    public void testRecoverReadJobDoesNotExist() throws IOException, JobRecoveryException {
+        HELPERS.recoverReadJob(UUID.randomUUID());
     }
 
     @Test

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpersImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpersImpl.java
@@ -258,7 +258,10 @@ class Ds3ClientHelpersImpl extends Ds3ClientHelpers {
         try {
             client.getActiveJobSpectraS3(new GetActiveJobSpectraS3Request(jobId));
         } catch (final FailedRequestException e) {
-            throw new JobRecoveryNotActiveException(jobId, e.getMessage());
+            if (e.getStatusCode() == 404) {
+                throw new JobRecoveryNotActiveException(jobId, e);
+            }
+            throw e;
         }
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpersImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpersImpl.java
@@ -210,9 +210,10 @@ class Ds3ClientHelpersImpl extends Ds3ClientHelpers {
 
     @Override
     public Ds3ClientHelpers.Job recoverWriteJob(final UUID jobId) throws IOException, JobRecoveryException {
+        innerVerifyJobActive(jobId);
         final ModifyJobSpectraS3Response jobResponse = this.client.modifyJobSpectraS3(new ModifyJobSpectraS3Request(jobId.toString()));
         if (JobRequestType.PUT != jobResponse.getMasterObjectListResult().getRequestType()) {
-            throw new JobRecoveryException(
+            throw new JobRecoveryTypeException(
                     RequestType.PUT.toString(),
                     jobResponse.getMasterObjectListResult().getRequestType().toString());
         }
@@ -230,9 +231,10 @@ class Ds3ClientHelpersImpl extends Ds3ClientHelpers {
     @Override
     //TODO add a partial object read recovery method.  That method will require the list of partial objects.
     public Ds3ClientHelpers.Job recoverReadJob(final UUID jobId) throws IOException, JobRecoveryException {
+        innerVerifyJobActive(jobId);
         final ModifyJobSpectraS3Response jobResponse = this.client.modifyJobSpectraS3(new ModifyJobSpectraS3Request(jobId.toString()));
         if (JobRequestType.GET != jobResponse.getMasterObjectListResult().getRequestType()){
-            throw new JobRecoveryException(
+            throw new JobRecoveryTypeException(
                     RequestType.GET.toString(),
                     jobResponse.getMasterObjectListResult().getRequestType().toString() );
         }
@@ -244,6 +246,20 @@ class Ds3ClientHelpersImpl extends Ds3ClientHelpers {
                 this.retryAfter,
                 this.retryDelay,
                 this.eventRunner);
+    }
+
+    /**
+     * Verifies that the specified job is active. If the job is not active, then a
+     * JobRecoveryNotActiveException is thrown.
+     * @throws IOException
+     * @throws JobRecoveryNotActiveException
+     */
+    private void innerVerifyJobActive(final UUID jobId) throws IOException, JobRecoveryNotActiveException {
+        try {
+            client.getActiveJobSpectraS3(new GetActiveJobSpectraS3Request(jobId));
+        } catch (final FailedRequestException e) {
+            throw new JobRecoveryNotActiveException(jobId, e.getMessage());
+        }
     }
 
     @Override

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryException.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryException.java
@@ -18,7 +18,11 @@ package com.spectralogic.ds3client.helpers;
 public class JobRecoveryException extends Exception {
     private static final long serialVersionUID = -4418169724222972364L;
     
-    JobRecoveryException(final String message) {
+    public JobRecoveryException(final String message) {
         super(message);
+    }
+
+    public JobRecoveryException(final String message, final Throwable cause) {
+        super(message, cause);
     }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryNotActiveException.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryNotActiveException.java
@@ -15,10 +15,15 @@
 
 package com.spectralogic.ds3client.helpers;
 
-public class JobRecoveryException extends Exception {
-    private static final long serialVersionUID = -4418169724222972364L;
-    
-    JobRecoveryException(final String message) {
-        super(message);
+import java.util.UUID;
+
+public class JobRecoveryNotActiveException extends JobRecoveryException {
+
+    JobRecoveryNotActiveException(final UUID jobId, final String message) {
+        super(buildMessage(jobId, message));
+    }
+
+    private static String buildMessage(final UUID jobId, final String message) {
+        return String.format("Cannot recover inactive job '%s': %s.", jobId.toString(), message);
     }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryNotActiveException.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryNotActiveException.java
@@ -17,13 +17,19 @@ package com.spectralogic.ds3client.helpers;
 
 import java.util.UUID;
 
+/**
+ * This exception represents a failure of an attempted recovery of a job
+ * performed using {@link Ds3ClientHelpers#recoverReadJob(UUID)} or
+ * {@link Ds3ClientHelpers#recoverWriteJob(UUID)} that is caused by the
+ * specified job not being active.
+ */
 public class JobRecoveryNotActiveException extends JobRecoveryException {
 
-    JobRecoveryNotActiveException(final UUID jobId, final String message) {
-        super(buildMessage(jobId, message));
+    JobRecoveryNotActiveException(final UUID jobId, final Throwable cause) {
+        super(buildMessage(jobId), cause);
     }
 
-    private static String buildMessage(final UUID jobId, final String message) {
-        return String.format("Cannot recover inactive job '%s': %s.", jobId.toString(), message);
+    private static String buildMessage(final UUID jobId) {
+        return String.format("Cannot recover inactive job '%s'", jobId.toString());
     }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryNotActiveException.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryNotActiveException.java
@@ -25,7 +25,7 @@ import java.util.UUID;
  */
 public class JobRecoveryNotActiveException extends JobRecoveryException {
 
-    JobRecoveryNotActiveException(final UUID jobId, final Throwable cause) {
+    public JobRecoveryNotActiveException(final UUID jobId, final Throwable cause) {
         super(buildMessage(jobId), cause);
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryTypeException.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryTypeException.java
@@ -15,10 +15,13 @@
 
 package com.spectralogic.ds3client.helpers;
 
-public class JobRecoveryException extends Exception {
-    private static final long serialVersionUID = -4418169724222972364L;
-    
-    JobRecoveryException(final String message) {
-        super(message);
+public class JobRecoveryTypeException extends JobRecoveryException {
+
+    JobRecoveryTypeException(final String expectedType, final String actualType) {
+        super(buildMessage(expectedType, actualType));
+    }
+
+    private static String buildMessage(final String expectedType, final String actualType) {
+        return String.format("Expected job type '%s' but the actual job was of type '%s'.", expectedType, actualType);
     }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryTypeException.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryTypeException.java
@@ -15,7 +15,17 @@
 
 package com.spectralogic.ds3client.helpers;
 
-public class JobRecoveryTypeException extends JobRecoveryException {
+import com.spectralogic.ds3client.models.JobRequestType;
+
+import java.util.UUID;
+
+/**
+ * This exception is thrown when an attempted recover is performed using {@link Ds3ClientHelpers}
+ * and the {@link JobRequestType} of the specified job does not match the type of recovery to be performed.
+ * {@link Ds3ClientHelpers#recoverReadJob(UUID)} requires the specified job to be of type {@link JobRequestType#GET}.
+ * {@link Ds3ClientHelpers#recoverWriteJob(UUID)} requires the specified job to be of type {@link JobRequestType#PUT}.
+ */
+class JobRecoveryTypeException extends JobRecoveryException {
 
     JobRecoveryTypeException(final String expectedType, final String actualType) {
         super(buildMessage(expectedType, actualType));

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryTypeException.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobRecoveryTypeException.java
@@ -25,9 +25,9 @@ import java.util.UUID;
  * {@link Ds3ClientHelpers#recoverReadJob(UUID)} requires the specified job to be of type {@link JobRequestType#GET}.
  * {@link Ds3ClientHelpers#recoverWriteJob(UUID)} requires the specified job to be of type {@link JobRequestType#PUT}.
  */
-class JobRecoveryTypeException extends JobRecoveryException {
+public class JobRecoveryTypeException extends JobRecoveryException {
 
-    JobRecoveryTypeException(final String expectedType, final String actualType) {
+    public JobRecoveryTypeException(final String expectedType, final String actualType) {
         super(buildMessage(expectedType, actualType));
     }
 


### PR DESCRIPTION
**Changes**
- Added verification that job is active before performing job recovery in helpers
- Modified `JobRecoveryException` so helper function signatures will not change
  - created `JobRecoveryTypeException` which extends `JobRecoverException` to specify failure due to type. This contains the behavior that was previously within `JobRecoveryException`
  - created `JobRecoveryNotActiveException` to specify failure related to the job not being active
- Added additional integration tests for both `recoverReadJob` and `recoverWriteJob` to verify canceled and non-existent jobs throw the new `JobRecoveryNotActiveException`