### PR TITLE
Fix copy-n-paste typo in docker README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ dependencies {
 ```
 ## Javadoc
 
-The latest javadoc is located at [http://spectralogic.github.io/ds3_java_sdkj/javadoc/](http://spectralogic.github.io/ds3_java_sdk/javadoc/)
+The latest javadoc is located at [http://spectralogic.github.io/ds3_java_sdk/javadoc/](http://spectralogic.github.io/ds3_java_sdk/javadoc/)
 
 ## Contributing
 If you would like to contribute to the source code, sign the [Contributors Agreement](https://developer.spectralogic.com/contributors-agreement/) and make sure that your source conforms to our [Java Style Guide](https://github.com/SpectraLogic/spectralogic.github.com/wiki/Java-Style-Guide).  For an overview of how we use Github, please review our [Github Workflow](https://github.com/SpectraLogic/spectralogic.github.com/wiki/Github-Workflow).

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,8 +1,8 @@
-# ds3-c-docker
-A public docker file that has all the dependencies to build and develop the DS3 C SDK
+# ds3-java-docker
+A public docker file that has all the dependencies to build and develop the DS3 Java SDK
 
 To use this docker container, run the following command:
 
 `sudo docker run -it spectralogic/ds3_java_docker_test`
 
-This will start the container with an interactive bash shell which will allow you to clone the ds3_c_sdk and then build it.
+This will start the container with an interactive bash shell which will allow you to clone the ds3_java_sdk and then build it.


### PR DESCRIPTION
Fix incorrect text for a referenced URL (which was correct) in top level README.md