### PR TITLE
Print the git HEAD rev hash before running tests

### DIFF
--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -6,19 +6,18 @@ echo DS3_ENDPOINT ${DS3_ENDPOINT}
 echo DS3_SECRET_KEY ${DS3_SECRET_KEY}
 echo DS3_ACCESS_KEY ${DS3_ACCESS_KEY}
 
-echo "cd /opt"
+set -x
+
 cd /opt
 
 if [ ${GIT_BRANCH} != "master" ]; then
-  echo git clone ${GIT_REPO} --branch ${GIT_BRANCH} --single-branch
   git clone ${GIT_REPO} --branch ${GIT_BRANCH} --single-branch
 else
-  echo git clone ${GIT_REPO}
   git clone ${GIT_REPO}
 fi
 
-echo "cd ds3_java_sdk"
 cd ds3_java_sdk
+git rev-parse HEAD
 
 ./gradlew jar
 ./gradlew test


### PR DESCRIPTION
denverm@dm-lt:~/code/ds3_java_sdk/docker$ ./run_tests.sh 
Using Git Repo: https://github.com/SpectraLogic/ds3_java_sdk.git
Using Git Branch: master
DS3_ENDPOINT sm2u-11.eng.sldomain.com
DS3_SECRET_KEY sKkCwmVf
DS3_ACCESS_KEY c3BlY3RyYQ==
+ cd /opt
+ '[' master '!=' master ']'
+ git clone https://github.com/SpectraLogic/ds3_java_sdk.git
Cloning into 'ds3_java_sdk'...
remote: Counting objects: 42399, done.
remote: Compressing objects: 100% (1818/1818), done.
remote: Total 42399 (delta 1636), reused 0 (delta 0), pack-reused 40491
Receiving objects: 100% (42399/42399), 21.17 MiB | 8.20 MiB/s, done.
Resolving deltas: 100% (30712/30712), done.
Checking connectivity... done.
+ cd ds3_java_sdk
+ git rev-parse HEAD
ff0e265937f24da49d00376cdd639e02ae5205d6
+ ./gradlew jar
:ds3-interfaces:compileJava
.
.
.