### PR TITLE
Fixing a test that really does not make sense to run as root.

### DIFF
--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/GetJobManagement_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/GetJobManagement_Test.java
@@ -328,6 +328,8 @@ public class GetJobManagement_Test {
 
     @Test(expected = AccessDeniedException.class)
     public void testReadRetryBugFixWithUnwritableDirectory() throws IOException, URISyntaxException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InterruptedException {
+        Assume.assumeFalse(iAmRoot());
+
         final String tempPathPrefix = null;
         final Path tempDirectoryPath = Files.createTempDirectory(Paths.get("."), tempPathPrefix);
 


### PR DESCRIPTION
Since there are other tests that exercise the ability to detect an error, not running this particular one as root is not a concern.