### PR TITLE
SDKPM - Using updateQueryParam over getQueryParams().put

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/AbortMultiPartUploadRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/AbortMultiPartUploadRequest.java
@@ -39,7 +39,8 @@ public class AbortMultiPartUploadRequest extends AbstractRequest {
         this.objectName = objectName;
         this.uploadId = uploadId.toString();
         
-        this.getQueryParams().put("upload_id", uploadId.toString());
+        this.updateQueryParam("upload_id", uploadId);
+
     }
 
     
@@ -48,7 +49,8 @@ public class AbortMultiPartUploadRequest extends AbstractRequest {
         this.objectName = objectName;
         this.uploadId = uploadId;
         
-        this.getQueryParams().put("upload_id", UrlEscapers.urlFragmentEscaper().escape(uploadId).replace("+", "%2B"));
+        this.updateQueryParam("upload_id", uploadId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/CompleteMultiPartUploadRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/CompleteMultiPartUploadRequest.java
@@ -48,7 +48,8 @@ public class CompleteMultiPartUploadRequest extends AbstractRequest {
         this.uploadId = uploadId.toString();
         this.requestPayload = requestPayload;
         
-        this.getQueryParams().put("upload_id", uploadId.toString());
+        this.updateQueryParam("upload_id", uploadId);
+
     }
 
     
@@ -58,7 +59,8 @@ public class CompleteMultiPartUploadRequest extends AbstractRequest {
         this.uploadId = uploadId;
         this.requestPayload = requestPayload;
         
-        this.getQueryParams().put("upload_id", UrlEscapers.urlFragmentEscaper().escape(uploadId).replace("+", "%2B"));
+        this.updateQueryParam("upload_id", uploadId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/GetObjectRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/GetObjectRequest.java
@@ -68,8 +68,10 @@ public class GetObjectRequest extends AbstractRequest {
         this.offset = offset;
         this.channel = channel;
         
-        this.getQueryParams().put("job", job.toString());
-        this.getQueryParams().put("offset", Long.toString(offset));
+        this.updateQueryParam("job", job);
+
+        this.updateQueryParam("offset", offset);
+
 
     }
 
@@ -81,8 +83,10 @@ public class GetObjectRequest extends AbstractRequest {
         this.offset = offset;
         this.channel = channel;
         
-        this.getQueryParams().put("job", UrlEscapers.urlFragmentEscaper().escape(job).replace("+", "%2B"));
-        this.getQueryParams().put("offset", Long.toString(offset));
+        this.updateQueryParam("job", job);
+
+        this.updateQueryParam("offset", offset);
+
 
     }
 
@@ -94,8 +98,10 @@ public class GetObjectRequest extends AbstractRequest {
         this.offset = offset;
         this.channel = Channels.newChannel(stream);
         
-        this.getQueryParams().put("job", job.toString());
-        this.getQueryParams().put("offset", Long.toString(offset));
+        this.updateQueryParam("job", job);
+
+        this.updateQueryParam("offset", offset);
+
 
     }
 
@@ -107,8 +113,10 @@ public class GetObjectRequest extends AbstractRequest {
         this.offset = offset;
         this.channel = Channels.newChannel(stream);
         
-        this.getQueryParams().put("job", UrlEscapers.urlFragmentEscaper().escape(job).replace("+", "%2B"));
-        this.getQueryParams().put("offset", Long.toString(offset));
+        this.updateQueryParam("job", job);
+
+        this.updateQueryParam("offset", offset);
+
 
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/ListMultiPartUploadPartsRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/ListMultiPartUploadPartsRequest.java
@@ -44,7 +44,8 @@ public class ListMultiPartUploadPartsRequest extends AbstractRequest {
         this.objectName = objectName;
         this.uploadId = uploadId.toString();
         
-        this.getQueryParams().put("upload_id", uploadId.toString());
+        this.updateQueryParam("upload_id", uploadId);
+
     }
 
     
@@ -53,7 +54,8 @@ public class ListMultiPartUploadPartsRequest extends AbstractRequest {
         this.objectName = objectName;
         this.uploadId = uploadId;
         
-        this.getQueryParams().put("upload_id", UrlEscapers.urlFragmentEscaper().escape(uploadId).replace("+", "%2B"));
+        this.updateQueryParam("upload_id", uploadId);
+
     }
 
     public ListMultiPartUploadPartsRequest withMaxParts(final int maxParts) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.java
@@ -53,8 +53,10 @@ public class PutMultiPartUploadPartRequest extends AbstractRequest {
         this.size = size;
         this.channel = channel;
         
-        this.getQueryParams().put("part_number", Integer.toString(partNumber));
-        this.getQueryParams().put("upload_id", uploadId.toString());
+        this.updateQueryParam("part_number", partNumber);
+
+        this.updateQueryParam("upload_id", uploadId);
+
         this.stream = new SeekableByteChannelInputStream(channel);
     }
 
@@ -67,8 +69,10 @@ public class PutMultiPartUploadPartRequest extends AbstractRequest {
         this.size = size;
         this.channel = channel;
         
-        this.getQueryParams().put("part_number", Integer.toString(partNumber));
-        this.getQueryParams().put("upload_id", UrlEscapers.urlFragmentEscaper().escape(uploadId).replace("+", "%2B"));
+        this.updateQueryParam("part_number", partNumber);
+
+        this.updateQueryParam("upload_id", uploadId);
+
         this.stream = new SeekableByteChannelInputStream(channel);
     }
 
@@ -81,8 +85,10 @@ public class PutMultiPartUploadPartRequest extends AbstractRequest {
         this.size = size;
         this.stream = stream;
         
-        this.getQueryParams().put("part_number", Integer.toString(partNumber));
-        this.getQueryParams().put("upload_id", uploadId.toString());
+        this.updateQueryParam("part_number", partNumber);
+
+        this.updateQueryParam("upload_id", uploadId);
+
     }
 
     
@@ -94,8 +100,10 @@ public class PutMultiPartUploadPartRequest extends AbstractRequest {
         this.size = size;
         this.stream = stream;
         
-        this.getQueryParams().put("part_number", Integer.toString(partNumber));
-        this.getQueryParams().put("upload_id", UrlEscapers.urlFragmentEscaper().escape(uploadId).replace("+", "%2B"));
+        this.updateQueryParam("part_number", partNumber);
+
+        this.updateQueryParam("upload_id", uploadId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/PutObjectRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/PutObjectRequest.java
@@ -73,8 +73,10 @@ public class PutObjectRequest extends AbstractRequest {
         this.channel = channel;
         this.stream = new SeekableByteChannelInputStream(channel);
         
-        this.getQueryParams().put("job", job.toString());
-        this.getQueryParams().put("offset", Long.toString(offset));
+        this.updateQueryParam("job", job);
+
+        this.updateQueryParam("offset", offset);
+
 
     }
 
@@ -88,8 +90,10 @@ public class PutObjectRequest extends AbstractRequest {
         this.channel = channel;
         this.stream = new SeekableByteChannelInputStream(channel);
         
-        this.getQueryParams().put("job", UrlEscapers.urlFragmentEscaper().escape(job).replace("+", "%2B"));
-        this.getQueryParams().put("offset", Long.toString(offset));
+        this.updateQueryParam("job", job);
+
+        this.updateQueryParam("offset", offset);
+
 
     }
 
@@ -102,8 +106,10 @@ public class PutObjectRequest extends AbstractRequest {
         this.offset = offset;
         this.stream = stream;
         
-        this.getQueryParams().put("job", job.toString());
-        this.getQueryParams().put("offset", Long.toString(offset));
+        this.updateQueryParam("job", job);
+
+        this.updateQueryParam("offset", offset);
+
 
     }
 
@@ -116,8 +122,10 @@ public class PutObjectRequest extends AbstractRequest {
         this.offset = offset;
         this.stream = stream;
         
-        this.getQueryParams().put("job", UrlEscapers.urlFragmentEscaper().escape(job).replace("+", "%2B"));
-        this.getQueryParams().put("offset", Long.toString(offset));
+        this.updateQueryParam("job", job);
+
+        this.updateQueryParam("offset", offset);
+
 
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ConvertStorageDomainToDs3TargetSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ConvertStorageDomainToDs3TargetSpectraS3Request.java
@@ -36,7 +36,8 @@ public class ConvertStorageDomainToDs3TargetSpectraS3Request extends AbstractReq
         this.storageDomain = storageDomain;
         this.convertToDs3Target = convertToDs3Target.toString();
         
-        this.getQueryParams().put("convert_to_ds3_target", convertToDs3Target.toString());
+        this.updateQueryParam("convert_to_ds3_target", convertToDs3Target);
+
     }
 
     
@@ -44,7 +45,8 @@ public class ConvertStorageDomainToDs3TargetSpectraS3Request extends AbstractReq
         this.storageDomain = storageDomain;
         this.convertToDs3Target = convertToDs3Target;
         
-        this.getQueryParams().put("convert_to_ds3_target", UrlEscapers.urlFragmentEscaper().escape(convertToDs3Target).replace("+", "%2B"));
+        this.updateQueryParam("convert_to_ds3_target", convertToDs3Target);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/DelegateCreateUserSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/DelegateCreateUserSpectraS3Request.java
@@ -37,7 +37,8 @@ public class DelegateCreateUserSpectraS3Request extends AbstractRequest {
     public DelegateCreateUserSpectraS3Request(final String name) {
         this.name = name;
         
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
+        this.updateQueryParam("name", name);
+
     }
 
     public DelegateCreateUserSpectraS3Request withId(final UUID id) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/DeleteFolderRecursivelySpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/DeleteFolderRecursivelySpectraS3Request.java
@@ -37,7 +37,8 @@ public class DeleteFolderRecursivelySpectraS3Request extends AbstractRequest {
         this.folder = folder;
         this.bucketId = bucketId;
         
-        this.getQueryParams().put("bucket_id", bucketId);
+        this.updateQueryParam("bucket_id", bucketId);
+
         this.getQueryParams().put("recursive", null);
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/EjectStorageDomainBlobsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/EjectStorageDomainBlobsSpectraS3Request.java
@@ -56,8 +56,10 @@ public class EjectStorageDomainBlobsSpectraS3Request extends AbstractRequest {
         this.getQueryParams().put("operation", "eject");
 
         this.getQueryParams().put("blobs", null);
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("storage_domain_id", storageDomainId.toString());
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
     }
 
     
@@ -69,8 +71,10 @@ public class EjectStorageDomainBlobsSpectraS3Request extends AbstractRequest {
         this.getQueryParams().put("operation", "eject");
 
         this.getQueryParams().put("blobs", null);
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("storage_domain_id", UrlEscapers.urlFragmentEscaper().escape(storageDomainId).replace("+", "%2B"));
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
     }
 
     public EjectStorageDomainBlobsSpectraS3Request withEjectLabel(final String ejectLabel) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/EjectStorageDomainSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/EjectStorageDomainSpectraS3Request.java
@@ -41,7 +41,8 @@ public class EjectStorageDomainSpectraS3Request extends AbstractRequest {
         
         this.getQueryParams().put("operation", "eject");
 
-        this.getQueryParams().put("storage_domain_id", storageDomainId.toString());
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
     }
 
     
@@ -50,7 +51,8 @@ public class EjectStorageDomainSpectraS3Request extends AbstractRequest {
         
         this.getQueryParams().put("operation", "eject");
 
-        this.getQueryParams().put("storage_domain_id", UrlEscapers.urlFragmentEscaper().escape(storageDomainId).replace("+", "%2B"));
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
     }
 
     public EjectStorageDomainSpectraS3Request withBucketId(final String bucketId) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/GetBucketCapacitySummarySpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/GetBucketCapacitySummarySpectraS3Request.java
@@ -51,8 +51,10 @@ public class GetBucketCapacitySummarySpectraS3Request extends AbstractRequest {
         this.bucketId = bucketId;
         this.storageDomainId = storageDomainId.toString();
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("storage_domain_id", storageDomainId.toString());
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
     }
 
     
@@ -60,8 +62,10 @@ public class GetBucketCapacitySummarySpectraS3Request extends AbstractRequest {
         this.bucketId = bucketId;
         this.storageDomainId = storageDomainId;
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("storage_domain_id", UrlEscapers.urlFragmentEscaper().escape(storageDomainId).replace("+", "%2B"));
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
     }
 
     public GetBucketCapacitySummarySpectraS3Request withPoolHealth(final PoolHealth poolHealth) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/GetJobChunksReadyForClientProcessingSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/GetJobChunksReadyForClientProcessingSpectraS3Request.java
@@ -37,14 +37,16 @@ public class GetJobChunksReadyForClientProcessingSpectraS3Request extends Abstra
     public GetJobChunksReadyForClientProcessingSpectraS3Request(final UUID job) {
         this.job = job.toString();
         
-        this.getQueryParams().put("job", job.toString());
+        this.updateQueryParam("job", job);
+
     }
 
     
     public GetJobChunksReadyForClientProcessingSpectraS3Request(final String job) {
         this.job = job;
         
-        this.getQueryParams().put("job", UrlEscapers.urlFragmentEscaper().escape(job).replace("+", "%2B"));
+        this.updateQueryParam("job", job);
+
     }
 
     public GetJobChunksReadyForClientProcessingSpectraS3Request withJobChunk(final UUID jobChunk) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/GetObjectDetailsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/GetObjectDetailsSpectraS3Request.java
@@ -35,7 +35,8 @@ public class GetObjectDetailsSpectraS3Request extends AbstractRequest {
         this.objectName = objectName;
         this.bucketId = bucketId;
         
-        this.getQueryParams().put("bucket_id", bucketId);
+        this.updateQueryParam("bucket_id", bucketId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/GetStorageDomainCapacitySummarySpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/GetStorageDomainCapacitySummarySpectraS3Request.java
@@ -48,14 +48,16 @@ public class GetStorageDomainCapacitySummarySpectraS3Request extends AbstractReq
     public GetStorageDomainCapacitySummarySpectraS3Request(final UUID storageDomainId) {
         this.storageDomainId = storageDomainId.toString();
         
-        this.getQueryParams().put("storage_domain_id", storageDomainId.toString());
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
     }
 
     
     public GetStorageDomainCapacitySummarySpectraS3Request(final String storageDomainId) {
         this.storageDomainId = storageDomainId;
         
-        this.getQueryParams().put("storage_domain_id", UrlEscapers.urlFragmentEscaper().escape(storageDomainId).replace("+", "%2B"));
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
     }
 
     public GetStorageDomainCapacitySummarySpectraS3Request withPoolHealth(final PoolHealth poolHealth) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ImportAzureTargetSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ImportAzureTargetSpectraS3Request.java
@@ -48,7 +48,8 @@ public class ImportAzureTargetSpectraS3Request extends AbstractRequest {
         
         this.getQueryParams().put("operation", "import");
 
-        this.getQueryParams().put("cloud_bucket_name", UrlEscapers.urlFragmentEscaper().escape(cloudBucketName).replace("+", "%2B"));
+        this.updateQueryParam("cloud_bucket_name", cloudBucketName);
+
     }
 
     public ImportAzureTargetSpectraS3Request withConflictResolutionMode(final ImportConflictResolutionMode conflictResolutionMode) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ImportS3TargetSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ImportS3TargetSpectraS3Request.java
@@ -48,7 +48,8 @@ public class ImportS3TargetSpectraS3Request extends AbstractRequest {
         
         this.getQueryParams().put("operation", "import");
 
-        this.getQueryParams().put("cloud_bucket_name", UrlEscapers.urlFragmentEscaper().escape(cloudBucketName).replace("+", "%2B"));
+        this.updateQueryParam("cloud_bucket_name", cloudBucketName);
+
     }
 
     public ImportS3TargetSpectraS3Request withConflictResolutionMode(final ImportConflictResolutionMode conflictResolutionMode) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ModifyAllAzureTargetsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ModifyAllAzureTargetsSpectraS3Request.java
@@ -32,7 +32,8 @@ public class ModifyAllAzureTargetsSpectraS3Request extends AbstractRequest {
     public ModifyAllAzureTargetsSpectraS3Request(final Quiesced quiesced) {
         this.quiesced = quiesced;
         
-        this.getQueryParams().put("quiesced", quiesced.toString());
+        this.updateQueryParam("quiesced", quiesced);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ModifyAllDs3TargetsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ModifyAllDs3TargetsSpectraS3Request.java
@@ -32,7 +32,8 @@ public class ModifyAllDs3TargetsSpectraS3Request extends AbstractRequest {
     public ModifyAllDs3TargetsSpectraS3Request(final Quiesced quiesced) {
         this.quiesced = quiesced;
         
-        this.getQueryParams().put("quiesced", quiesced.toString());
+        this.updateQueryParam("quiesced", quiesced);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ModifyAllPoolsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ModifyAllPoolsSpectraS3Request.java
@@ -32,7 +32,8 @@ public class ModifyAllPoolsSpectraS3Request extends AbstractRequest {
     public ModifyAllPoolsSpectraS3Request(final Quiesced quiesced) {
         this.quiesced = quiesced;
         
-        this.getQueryParams().put("quiesced", quiesced.toString());
+        this.updateQueryParam("quiesced", quiesced);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ModifyAllS3TargetsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ModifyAllS3TargetsSpectraS3Request.java
@@ -32,7 +32,8 @@ public class ModifyAllS3TargetsSpectraS3Request extends AbstractRequest {
     public ModifyAllS3TargetsSpectraS3Request(final Quiesced quiesced) {
         this.quiesced = quiesced;
         
-        this.getQueryParams().put("quiesced", quiesced.toString());
+        this.updateQueryParam("quiesced", quiesced);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ModifyAllTapePartitionsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ModifyAllTapePartitionsSpectraS3Request.java
@@ -32,7 +32,8 @@ public class ModifyAllTapePartitionsSpectraS3Request extends AbstractRequest {
     public ModifyAllTapePartitionsSpectraS3Request(final Quiesced quiesced) {
         this.quiesced = quiesced;
         
-        this.getQueryParams().put("quiesced", quiesced.toString());
+        this.updateQueryParam("quiesced", quiesced);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutAzureDataReplicationRuleSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutAzureDataReplicationRuleSpectraS3Request.java
@@ -44,9 +44,12 @@ public class PutAzureDataReplicationRuleSpectraS3Request extends AbstractRequest
         this.targetId = targetId.toString();
         this.type = type;
         
-        this.getQueryParams().put("data_policy_id", dataPolicyId.toString());
-        this.getQueryParams().put("target_id", targetId.toString());
-        this.getQueryParams().put("type", type.toString());
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("target_id", targetId);
+
+        this.updateQueryParam("type", type);
+
     }
 
     
@@ -55,9 +58,12 @@ public class PutAzureDataReplicationRuleSpectraS3Request extends AbstractRequest
         this.targetId = targetId;
         this.type = type;
         
-        this.getQueryParams().put("data_policy_id", UrlEscapers.urlFragmentEscaper().escape(dataPolicyId).replace("+", "%2B"));
-        this.getQueryParams().put("target_id", UrlEscapers.urlFragmentEscaper().escape(targetId).replace("+", "%2B"));
-        this.getQueryParams().put("type", type.toString());
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("target_id", targetId);
+
+        this.updateQueryParam("type", type);
+
     }
 
     public PutAzureDataReplicationRuleSpectraS3Request withMaxBlobPartSizeInBytes(final long maxBlobPartSizeInBytes) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutAzureTargetBucketNameSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutAzureTargetBucketNameSpectraS3Request.java
@@ -39,9 +39,12 @@ public class PutAzureTargetBucketNameSpectraS3Request extends AbstractRequest {
         this.name = name;
         this.targetId = targetId.toString();
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
-        this.getQueryParams().put("target_id", targetId.toString());
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("name", name);
+
+        this.updateQueryParam("target_id", targetId);
+
     }
 
     
@@ -50,9 +53,12 @@ public class PutAzureTargetBucketNameSpectraS3Request extends AbstractRequest {
         this.name = name;
         this.targetId = targetId;
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
-        this.getQueryParams().put("target_id", UrlEscapers.urlFragmentEscaper().escape(targetId).replace("+", "%2B"));
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("name", name);
+
+        this.updateQueryParam("target_id", targetId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutAzureTargetFailureNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutAzureTargetFailureNotificationRegistrationSpectraS3Request.java
@@ -41,7 +41,8 @@ public class PutAzureTargetFailureNotificationRegistrationSpectraS3Request exten
     public PutAzureTargetFailureNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         this.notificationEndPoint = notificationEndPoint;
         
-        this.getQueryParams().put("notification_end_point", UrlEscapers.urlFragmentEscaper().escape(notificationEndPoint).replace("+", "%2B"));
+        this.updateQueryParam("notification_end_point", notificationEndPoint);
+
     }
 
     public PutAzureTargetFailureNotificationRegistrationSpectraS3Request withFormat(final HttpResponseFormatType format) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutAzureTargetReadPreferenceSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutAzureTargetReadPreferenceSpectraS3Request.java
@@ -40,9 +40,12 @@ public class PutAzureTargetReadPreferenceSpectraS3Request extends AbstractReques
         this.readPreference = readPreference;
         this.targetId = targetId.toString();
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("read_preference", readPreference.toString());
-        this.getQueryParams().put("target_id", targetId.toString());
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("read_preference", readPreference);
+
+        this.updateQueryParam("target_id", targetId);
+
     }
 
     
@@ -51,9 +54,12 @@ public class PutAzureTargetReadPreferenceSpectraS3Request extends AbstractReques
         this.readPreference = readPreference;
         this.targetId = targetId;
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("read_preference", readPreference.toString());
-        this.getQueryParams().put("target_id", UrlEscapers.urlFragmentEscaper().escape(targetId).replace("+", "%2B"));
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("read_preference", readPreference);
+
+        this.updateQueryParam("target_id", targetId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutBucketAclForGroupSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutBucketAclForGroupSpectraS3Request.java
@@ -40,9 +40,12 @@ public class PutBucketAclForGroupSpectraS3Request extends AbstractRequest {
         this.groupId = groupId.toString();
         this.permission = permission;
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("group_id", groupId.toString());
-        this.getQueryParams().put("permission", permission.toString());
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("group_id", groupId);
+
+        this.updateQueryParam("permission", permission);
+
     }
 
     
@@ -51,9 +54,12 @@ public class PutBucketAclForGroupSpectraS3Request extends AbstractRequest {
         this.groupId = groupId;
         this.permission = permission;
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("group_id", UrlEscapers.urlFragmentEscaper().escape(groupId).replace("+", "%2B"));
-        this.getQueryParams().put("permission", permission.toString());
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("group_id", groupId);
+
+        this.updateQueryParam("permission", permission);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutBucketAclForUserSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutBucketAclForUserSpectraS3Request.java
@@ -40,9 +40,12 @@ public class PutBucketAclForUserSpectraS3Request extends AbstractRequest {
         this.permission = permission;
         this.userId = userId.toString();
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("permission", permission.toString());
-        this.getQueryParams().put("user_id", userId.toString());
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("permission", permission);
+
+        this.updateQueryParam("user_id", userId);
+
     }
 
     
@@ -51,9 +54,12 @@ public class PutBucketAclForUserSpectraS3Request extends AbstractRequest {
         this.permission = permission;
         this.userId = userId;
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("permission", permission.toString());
-        this.getQueryParams().put("user_id", UrlEscapers.urlFragmentEscaper().escape(userId).replace("+", "%2B"));
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("permission", permission);
+
+        this.updateQueryParam("user_id", userId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutBucketSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutBucketSpectraS3Request.java
@@ -39,7 +39,8 @@ public class PutBucketSpectraS3Request extends AbstractRequest {
     public PutBucketSpectraS3Request(final String name) {
         this.name = name;
         
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
+        this.updateQueryParam("name", name);
+
     }
 
     public PutBucketSpectraS3Request withDataPolicyId(final UUID dataPolicyId) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDataPersistenceRuleSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDataPersistenceRuleSpectraS3Request.java
@@ -47,10 +47,14 @@ public class PutDataPersistenceRuleSpectraS3Request extends AbstractRequest {
         this.storageDomainId = storageDomainId.toString();
         this.type = type;
         
-        this.getQueryParams().put("data_policy_id", dataPolicyId.toString());
-        this.getQueryParams().put("isolation_level", isolationLevel.toString());
-        this.getQueryParams().put("storage_domain_id", storageDomainId.toString());
-        this.getQueryParams().put("type", type.toString());
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("isolation_level", isolationLevel);
+
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
+        this.updateQueryParam("type", type);
+
     }
 
     
@@ -60,10 +64,14 @@ public class PutDataPersistenceRuleSpectraS3Request extends AbstractRequest {
         this.storageDomainId = storageDomainId;
         this.type = type;
         
-        this.getQueryParams().put("data_policy_id", UrlEscapers.urlFragmentEscaper().escape(dataPolicyId).replace("+", "%2B"));
-        this.getQueryParams().put("isolation_level", isolationLevel.toString());
-        this.getQueryParams().put("storage_domain_id", UrlEscapers.urlFragmentEscaper().escape(storageDomainId).replace("+", "%2B"));
-        this.getQueryParams().put("type", type.toString());
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("isolation_level", isolationLevel);
+
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
+        this.updateQueryParam("type", type);
+
     }
 
     public PutDataPersistenceRuleSpectraS3Request withMinimumDaysToRetain(final Integer minimumDaysToRetain) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDataPolicyAclForGroupSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDataPolicyAclForGroupSpectraS3Request.java
@@ -36,8 +36,10 @@ public class PutDataPolicyAclForGroupSpectraS3Request extends AbstractRequest {
         this.dataPolicyId = dataPolicyId.toString();
         this.groupId = groupId.toString();
         
-        this.getQueryParams().put("data_policy_id", dataPolicyId.toString());
-        this.getQueryParams().put("group_id", groupId.toString());
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("group_id", groupId);
+
     }
 
     
@@ -45,8 +47,10 @@ public class PutDataPolicyAclForGroupSpectraS3Request extends AbstractRequest {
         this.dataPolicyId = dataPolicyId;
         this.groupId = groupId;
         
-        this.getQueryParams().put("data_policy_id", UrlEscapers.urlFragmentEscaper().escape(dataPolicyId).replace("+", "%2B"));
-        this.getQueryParams().put("group_id", UrlEscapers.urlFragmentEscaper().escape(groupId).replace("+", "%2B"));
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("group_id", groupId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDataPolicyAclForUserSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDataPolicyAclForUserSpectraS3Request.java
@@ -36,8 +36,10 @@ public class PutDataPolicyAclForUserSpectraS3Request extends AbstractRequest {
         this.dataPolicyId = dataPolicyId.toString();
         this.userId = userId.toString();
         
-        this.getQueryParams().put("data_policy_id", dataPolicyId.toString());
-        this.getQueryParams().put("user_id", userId.toString());
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("user_id", userId);
+
     }
 
     
@@ -45,8 +47,10 @@ public class PutDataPolicyAclForUserSpectraS3Request extends AbstractRequest {
         this.dataPolicyId = dataPolicyId;
         this.userId = userId;
         
-        this.getQueryParams().put("data_policy_id", UrlEscapers.urlFragmentEscaper().escape(dataPolicyId).replace("+", "%2B"));
-        this.getQueryParams().put("user_id", UrlEscapers.urlFragmentEscaper().escape(userId).replace("+", "%2B"));
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("user_id", userId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDataPolicySpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDataPolicySpectraS3Request.java
@@ -60,7 +60,8 @@ public class PutDataPolicySpectraS3Request extends AbstractRequest {
     public PutDataPolicySpectraS3Request(final String name) {
         this.name = name;
         
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
+        this.updateQueryParam("name", name);
+
     }
 
     public PutDataPolicySpectraS3Request withAlwaysForcePutJobCreation(final boolean alwaysForcePutJobCreation) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDs3DataReplicationRuleSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDs3DataReplicationRuleSpectraS3Request.java
@@ -44,9 +44,12 @@ public class PutDs3DataReplicationRuleSpectraS3Request extends AbstractRequest {
         this.targetId = targetId.toString();
         this.type = type;
         
-        this.getQueryParams().put("data_policy_id", dataPolicyId.toString());
-        this.getQueryParams().put("target_id", targetId.toString());
-        this.getQueryParams().put("type", type.toString());
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("target_id", targetId);
+
+        this.updateQueryParam("type", type);
+
     }
 
     
@@ -55,9 +58,12 @@ public class PutDs3DataReplicationRuleSpectraS3Request extends AbstractRequest {
         this.targetId = targetId;
         this.type = type;
         
-        this.getQueryParams().put("data_policy_id", UrlEscapers.urlFragmentEscaper().escape(dataPolicyId).replace("+", "%2B"));
-        this.getQueryParams().put("target_id", UrlEscapers.urlFragmentEscaper().escape(targetId).replace("+", "%2B"));
-        this.getQueryParams().put("type", type.toString());
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("target_id", targetId);
+
+        this.updateQueryParam("type", type);
+
     }
 
     public PutDs3DataReplicationRuleSpectraS3Request withReplicateDeletes(final boolean replicateDeletes) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDs3TargetReadPreferenceSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutDs3TargetReadPreferenceSpectraS3Request.java
@@ -40,9 +40,12 @@ public class PutDs3TargetReadPreferenceSpectraS3Request extends AbstractRequest 
         this.readPreference = readPreference;
         this.targetId = targetId.toString();
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("read_preference", readPreference.toString());
-        this.getQueryParams().put("target_id", targetId.toString());
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("read_preference", readPreference);
+
+        this.updateQueryParam("target_id", targetId);
+
     }
 
     
@@ -51,9 +54,12 @@ public class PutDs3TargetReadPreferenceSpectraS3Request extends AbstractRequest 
         this.readPreference = readPreference;
         this.targetId = targetId;
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("read_preference", readPreference.toString());
-        this.getQueryParams().put("target_id", UrlEscapers.urlFragmentEscaper().escape(targetId).replace("+", "%2B"));
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("read_preference", readPreference);
+
+        this.updateQueryParam("target_id", targetId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGlobalBucketAclForGroupSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGlobalBucketAclForGroupSpectraS3Request.java
@@ -37,8 +37,10 @@ public class PutGlobalBucketAclForGroupSpectraS3Request extends AbstractRequest 
         this.groupId = groupId.toString();
         this.permission = permission;
         
-        this.getQueryParams().put("group_id", groupId.toString());
-        this.getQueryParams().put("permission", permission.toString());
+        this.updateQueryParam("group_id", groupId);
+
+        this.updateQueryParam("permission", permission);
+
     }
 
     
@@ -46,8 +48,10 @@ public class PutGlobalBucketAclForGroupSpectraS3Request extends AbstractRequest 
         this.groupId = groupId;
         this.permission = permission;
         
-        this.getQueryParams().put("group_id", UrlEscapers.urlFragmentEscaper().escape(groupId).replace("+", "%2B"));
-        this.getQueryParams().put("permission", permission.toString());
+        this.updateQueryParam("group_id", groupId);
+
+        this.updateQueryParam("permission", permission);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGlobalBucketAclForUserSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGlobalBucketAclForUserSpectraS3Request.java
@@ -37,8 +37,10 @@ public class PutGlobalBucketAclForUserSpectraS3Request extends AbstractRequest {
         this.permission = permission;
         this.userId = userId.toString();
         
-        this.getQueryParams().put("permission", permission.toString());
-        this.getQueryParams().put("user_id", userId.toString());
+        this.updateQueryParam("permission", permission);
+
+        this.updateQueryParam("user_id", userId);
+
     }
 
     
@@ -46,8 +48,10 @@ public class PutGlobalBucketAclForUserSpectraS3Request extends AbstractRequest {
         this.permission = permission;
         this.userId = userId;
         
-        this.getQueryParams().put("permission", permission.toString());
-        this.getQueryParams().put("user_id", UrlEscapers.urlFragmentEscaper().escape(userId).replace("+", "%2B"));
+        this.updateQueryParam("permission", permission);
+
+        this.updateQueryParam("user_id", userId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGlobalDataPolicyAclForGroupSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGlobalDataPolicyAclForGroupSpectraS3Request.java
@@ -33,14 +33,16 @@ public class PutGlobalDataPolicyAclForGroupSpectraS3Request extends AbstractRequ
     public PutGlobalDataPolicyAclForGroupSpectraS3Request(final UUID groupId) {
         this.groupId = groupId.toString();
         
-        this.getQueryParams().put("group_id", groupId.toString());
+        this.updateQueryParam("group_id", groupId);
+
     }
 
     
     public PutGlobalDataPolicyAclForGroupSpectraS3Request(final String groupId) {
         this.groupId = groupId;
         
-        this.getQueryParams().put("group_id", UrlEscapers.urlFragmentEscaper().escape(groupId).replace("+", "%2B"));
+        this.updateQueryParam("group_id", groupId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGlobalDataPolicyAclForUserSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGlobalDataPolicyAclForUserSpectraS3Request.java
@@ -33,14 +33,16 @@ public class PutGlobalDataPolicyAclForUserSpectraS3Request extends AbstractReque
     public PutGlobalDataPolicyAclForUserSpectraS3Request(final UUID userId) {
         this.userId = userId.toString();
         
-        this.getQueryParams().put("user_id", userId.toString());
+        this.updateQueryParam("user_id", userId);
+
     }
 
     
     public PutGlobalDataPolicyAclForUserSpectraS3Request(final String userId) {
         this.userId = userId;
         
-        this.getQueryParams().put("user_id", UrlEscapers.urlFragmentEscaper().escape(userId).replace("+", "%2B"));
+        this.updateQueryParam("user_id", userId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGroupGroupMemberSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGroupGroupMemberSpectraS3Request.java
@@ -36,8 +36,10 @@ public class PutGroupGroupMemberSpectraS3Request extends AbstractRequest {
         this.groupId = groupId.toString();
         this.memberGroupId = memberGroupId.toString();
         
-        this.getQueryParams().put("group_id", groupId.toString());
-        this.getQueryParams().put("member_group_id", memberGroupId.toString());
+        this.updateQueryParam("group_id", groupId);
+
+        this.updateQueryParam("member_group_id", memberGroupId);
+
     }
 
     
@@ -45,8 +47,10 @@ public class PutGroupGroupMemberSpectraS3Request extends AbstractRequest {
         this.groupId = groupId;
         this.memberGroupId = memberGroupId;
         
-        this.getQueryParams().put("group_id", UrlEscapers.urlFragmentEscaper().escape(groupId).replace("+", "%2B"));
-        this.getQueryParams().put("member_group_id", UrlEscapers.urlFragmentEscaper().escape(memberGroupId).replace("+", "%2B"));
+        this.updateQueryParam("group_id", groupId);
+
+        this.updateQueryParam("member_group_id", memberGroupId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGroupSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutGroupSpectraS3Request.java
@@ -32,7 +32,8 @@ public class PutGroupSpectraS3Request extends AbstractRequest {
     public PutGroupSpectraS3Request(final String name) {
         this.name = name;
         
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
+        this.updateQueryParam("name", name);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutPoolPartitionSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutPoolPartitionSpectraS3Request.java
@@ -36,8 +36,10 @@ public class PutPoolPartitionSpectraS3Request extends AbstractRequest {
         this.name = name;
         this.type = type;
         
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
-        this.getQueryParams().put("type", type.toString());
+        this.updateQueryParam("name", name);
+
+        this.updateQueryParam("type", type);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutPoolStorageDomainMemberSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutPoolStorageDomainMemberSpectraS3Request.java
@@ -39,8 +39,10 @@ public class PutPoolStorageDomainMemberSpectraS3Request extends AbstractRequest 
         this.poolPartitionId = poolPartitionId.toString();
         this.storageDomainId = storageDomainId.toString();
         
-        this.getQueryParams().put("pool_partition_id", poolPartitionId.toString());
-        this.getQueryParams().put("storage_domain_id", storageDomainId.toString());
+        this.updateQueryParam("pool_partition_id", poolPartitionId);
+
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
     }
 
     
@@ -48,8 +50,10 @@ public class PutPoolStorageDomainMemberSpectraS3Request extends AbstractRequest 
         this.poolPartitionId = poolPartitionId;
         this.storageDomainId = storageDomainId;
         
-        this.getQueryParams().put("pool_partition_id", UrlEscapers.urlFragmentEscaper().escape(poolPartitionId).replace("+", "%2B"));
-        this.getQueryParams().put("storage_domain_id", UrlEscapers.urlFragmentEscaper().escape(storageDomainId).replace("+", "%2B"));
+        this.updateQueryParam("pool_partition_id", poolPartitionId);
+
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
     }
 
     public PutPoolStorageDomainMemberSpectraS3Request withWritePreference(final WritePreferenceLevel writePreference) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutS3DataReplicationRuleSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutS3DataReplicationRuleSpectraS3Request.java
@@ -47,9 +47,12 @@ public class PutS3DataReplicationRuleSpectraS3Request extends AbstractRequest {
         this.targetId = targetId.toString();
         this.type = type;
         
-        this.getQueryParams().put("data_policy_id", dataPolicyId.toString());
-        this.getQueryParams().put("target_id", targetId.toString());
-        this.getQueryParams().put("type", type.toString());
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("target_id", targetId);
+
+        this.updateQueryParam("type", type);
+
     }
 
     
@@ -58,9 +61,12 @@ public class PutS3DataReplicationRuleSpectraS3Request extends AbstractRequest {
         this.targetId = targetId;
         this.type = type;
         
-        this.getQueryParams().put("data_policy_id", UrlEscapers.urlFragmentEscaper().escape(dataPolicyId).replace("+", "%2B"));
-        this.getQueryParams().put("target_id", UrlEscapers.urlFragmentEscaper().escape(targetId).replace("+", "%2B"));
-        this.getQueryParams().put("type", type.toString());
+        this.updateQueryParam("data_policy_id", dataPolicyId);
+
+        this.updateQueryParam("target_id", targetId);
+
+        this.updateQueryParam("type", type);
+
     }
 
     public PutS3DataReplicationRuleSpectraS3Request withInitialDataPlacement(final S3InitialDataPlacementPolicy initialDataPlacement) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutS3TargetBucketNameSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutS3TargetBucketNameSpectraS3Request.java
@@ -39,9 +39,12 @@ public class PutS3TargetBucketNameSpectraS3Request extends AbstractRequest {
         this.name = name;
         this.targetId = targetId.toString();
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
-        this.getQueryParams().put("target_id", targetId.toString());
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("name", name);
+
+        this.updateQueryParam("target_id", targetId);
+
     }
 
     
@@ -50,9 +53,12 @@ public class PutS3TargetBucketNameSpectraS3Request extends AbstractRequest {
         this.name = name;
         this.targetId = targetId;
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
-        this.getQueryParams().put("target_id", UrlEscapers.urlFragmentEscaper().escape(targetId).replace("+", "%2B"));
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("name", name);
+
+        this.updateQueryParam("target_id", targetId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutS3TargetFailureNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutS3TargetFailureNotificationRegistrationSpectraS3Request.java
@@ -41,7 +41,8 @@ public class PutS3TargetFailureNotificationRegistrationSpectraS3Request extends 
     public PutS3TargetFailureNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         this.notificationEndPoint = notificationEndPoint;
         
-        this.getQueryParams().put("notification_end_point", UrlEscapers.urlFragmentEscaper().escape(notificationEndPoint).replace("+", "%2B"));
+        this.updateQueryParam("notification_end_point", notificationEndPoint);
+
     }
 
     public PutS3TargetFailureNotificationRegistrationSpectraS3Request withFormat(final HttpResponseFormatType format) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutS3TargetReadPreferenceSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutS3TargetReadPreferenceSpectraS3Request.java
@@ -40,9 +40,12 @@ public class PutS3TargetReadPreferenceSpectraS3Request extends AbstractRequest {
         this.readPreference = readPreference;
         this.targetId = targetId.toString();
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("read_preference", readPreference.toString());
-        this.getQueryParams().put("target_id", targetId.toString());
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("read_preference", readPreference);
+
+        this.updateQueryParam("target_id", targetId);
+
     }
 
     
@@ -51,9 +54,12 @@ public class PutS3TargetReadPreferenceSpectraS3Request extends AbstractRequest {
         this.readPreference = readPreference;
         this.targetId = targetId;
         
-        this.getQueryParams().put("bucket_id", bucketId);
-        this.getQueryParams().put("read_preference", readPreference.toString());
-        this.getQueryParams().put("target_id", UrlEscapers.urlFragmentEscaper().escape(targetId).replace("+", "%2B"));
+        this.updateQueryParam("bucket_id", bucketId);
+
+        this.updateQueryParam("read_preference", readPreference);
+
+        this.updateQueryParam("target_id", targetId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutStorageDomainSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutStorageDomainSpectraS3Request.java
@@ -61,7 +61,8 @@ public class PutStorageDomainSpectraS3Request extends AbstractRequest {
     public PutStorageDomainSpectraS3Request(final String name) {
         this.name = name;
         
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
+        this.updateQueryParam("name", name);
+
     }
 
     public PutStorageDomainSpectraS3Request withAutoEjectMediaFullThreshold(final Long autoEjectMediaFullThreshold) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutTapeDensityDirectiveSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutTapeDensityDirectiveSpectraS3Request.java
@@ -41,9 +41,12 @@ public class PutTapeDensityDirectiveSpectraS3Request extends AbstractRequest {
         this.partitionId = partitionId.toString();
         this.tapeType = tapeType;
         
-        this.getQueryParams().put("density", density.toString());
-        this.getQueryParams().put("partition_id", partitionId.toString());
-        this.getQueryParams().put("tape_type", tapeType.toString());
+        this.updateQueryParam("density", density);
+
+        this.updateQueryParam("partition_id", partitionId);
+
+        this.updateQueryParam("tape_type", tapeType);
+
     }
 
     
@@ -52,9 +55,12 @@ public class PutTapeDensityDirectiveSpectraS3Request extends AbstractRequest {
         this.partitionId = partitionId;
         this.tapeType = tapeType;
         
-        this.getQueryParams().put("density", density.toString());
-        this.getQueryParams().put("partition_id", UrlEscapers.urlFragmentEscaper().escape(partitionId).replace("+", "%2B"));
-        this.getQueryParams().put("tape_type", tapeType.toString());
+        this.updateQueryParam("density", density);
+
+        this.updateQueryParam("partition_id", partitionId);
+
+        this.updateQueryParam("tape_type", tapeType);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutTapeStorageDomainMemberSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutTapeStorageDomainMemberSpectraS3Request.java
@@ -43,9 +43,12 @@ public class PutTapeStorageDomainMemberSpectraS3Request extends AbstractRequest 
         this.tapePartitionId = tapePartitionId.toString();
         this.tapeType = tapeType;
         
-        this.getQueryParams().put("storage_domain_id", storageDomainId.toString());
-        this.getQueryParams().put("tape_partition_id", tapePartitionId.toString());
-        this.getQueryParams().put("tape_type", tapeType.toString());
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
+        this.updateQueryParam("tape_partition_id", tapePartitionId);
+
+        this.updateQueryParam("tape_type", tapeType);
+
     }
 
     
@@ -54,9 +57,12 @@ public class PutTapeStorageDomainMemberSpectraS3Request extends AbstractRequest 
         this.tapePartitionId = tapePartitionId;
         this.tapeType = tapeType;
         
-        this.getQueryParams().put("storage_domain_id", UrlEscapers.urlFragmentEscaper().escape(storageDomainId).replace("+", "%2B"));
-        this.getQueryParams().put("tape_partition_id", UrlEscapers.urlFragmentEscaper().escape(tapePartitionId).replace("+", "%2B"));
-        this.getQueryParams().put("tape_type", tapeType.toString());
+        this.updateQueryParam("storage_domain_id", storageDomainId);
+
+        this.updateQueryParam("tape_partition_id", tapePartitionId);
+
+        this.updateQueryParam("tape_type", tapeType);
+
     }
 
     public PutTapeStorageDomainMemberSpectraS3Request withWritePreference(final WritePreferenceLevel writePreference) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutUserGroupMemberSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/PutUserGroupMemberSpectraS3Request.java
@@ -36,8 +36,10 @@ public class PutUserGroupMemberSpectraS3Request extends AbstractRequest {
         this.groupId = groupId.toString();
         this.memberUserId = memberUserId.toString();
         
-        this.getQueryParams().put("group_id", groupId.toString());
-        this.getQueryParams().put("member_user_id", memberUserId.toString());
+        this.updateQueryParam("group_id", groupId);
+
+        this.updateQueryParam("member_user_id", memberUserId);
+
     }
 
     
@@ -45,8 +47,10 @@ public class PutUserGroupMemberSpectraS3Request extends AbstractRequest {
         this.groupId = groupId;
         this.memberUserId = memberUserId;
         
-        this.getQueryParams().put("group_id", UrlEscapers.urlFragmentEscaper().escape(groupId).replace("+", "%2B"));
-        this.getQueryParams().put("member_user_id", UrlEscapers.urlFragmentEscaper().escape(memberUserId).replace("+", "%2B"));
+        this.updateQueryParam("group_id", groupId);
+
+        this.updateQueryParam("member_user_id", memberUserId);
+
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/RawImportAllTapesSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/RawImportAllTapesSpectraS3Request.java
@@ -40,7 +40,8 @@ public class RawImportAllTapesSpectraS3Request extends AbstractRequest {
         
         this.getQueryParams().put("operation", "import");
 
-        this.getQueryParams().put("bucket_id", bucketId);
+        this.updateQueryParam("bucket_id", bucketId);
+
     }
 
     public RawImportAllTapesSpectraS3Request withStorageDomainId(final UUID storageDomainId) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/RawImportTapeSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/RawImportTapeSpectraS3Request.java
@@ -43,7 +43,8 @@ public class RawImportTapeSpectraS3Request extends AbstractRequest {
         
         this.getQueryParams().put("operation", "import");
 
-        this.getQueryParams().put("bucket_id", bucketId);
+        this.updateQueryParam("bucket_id", bucketId);
+
     }
 
     
@@ -53,7 +54,8 @@ public class RawImportTapeSpectraS3Request extends AbstractRequest {
         
         this.getQueryParams().put("operation", "import");
 
-        this.getQueryParams().put("bucket_id", bucketId);
+        this.updateQueryParam("bucket_id", bucketId);
+
     }
 
     public RawImportTapeSpectraS3Request withStorageDomainId(final UUID storageDomainId) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/RegisterAzureTargetSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/RegisterAzureTargetSpectraS3Request.java
@@ -52,9 +52,12 @@ public class RegisterAzureTargetSpectraS3Request extends AbstractRequest {
         this.accountName = accountName;
         this.name = name;
         
-        this.getQueryParams().put("account_key", UrlEscapers.urlFragmentEscaper().escape(accountKey).replace("+", "%2B"));
-        this.getQueryParams().put("account_name", UrlEscapers.urlFragmentEscaper().escape(accountName).replace("+", "%2B"));
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
+        this.updateQueryParam("account_key", accountKey);
+
+        this.updateQueryParam("account_name", accountName);
+
+        this.updateQueryParam("name", name);
+
     }
 
     public RegisterAzureTargetSpectraS3Request withAutoVerifyFrequencyInDays(final Integer autoVerifyFrequencyInDays) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/RegisterDs3TargetSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/RegisterDs3TargetSpectraS3Request.java
@@ -60,10 +60,14 @@ public class RegisterDs3TargetSpectraS3Request extends AbstractRequest {
         this.dataPathEndPoint = dataPathEndPoint;
         this.name = name;
         
-        this.getQueryParams().put("admin_auth_id", UrlEscapers.urlFragmentEscaper().escape(adminAuthId).replace("+", "%2B"));
-        this.getQueryParams().put("admin_secret_key", UrlEscapers.urlFragmentEscaper().escape(adminSecretKey).replace("+", "%2B"));
-        this.getQueryParams().put("data_path_end_point", UrlEscapers.urlFragmentEscaper().escape(dataPathEndPoint).replace("+", "%2B"));
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
+        this.updateQueryParam("admin_auth_id", adminAuthId);
+
+        this.updateQueryParam("admin_secret_key", adminSecretKey);
+
+        this.updateQueryParam("data_path_end_point", dataPathEndPoint);
+
+        this.updateQueryParam("name", name);
+
     }
 
     public RegisterDs3TargetSpectraS3Request withAccessControlReplication(final Ds3TargetAccessControlReplication accessControlReplication) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/RegisterS3TargetSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/RegisterS3TargetSpectraS3Request.java
@@ -71,9 +71,12 @@ public class RegisterS3TargetSpectraS3Request extends AbstractRequest {
         this.name = name;
         this.secretKey = secretKey;
         
-        this.getQueryParams().put("access_key", UrlEscapers.urlFragmentEscaper().escape(accessKey).replace("+", "%2B"));
-        this.getQueryParams().put("name", UrlEscapers.urlFragmentEscaper().escape(name).replace("+", "%2B"));
-        this.getQueryParams().put("secret_key", UrlEscapers.urlFragmentEscaper().escape(secretKey).replace("+", "%2B"));
+        this.updateQueryParam("access_key", accessKey);
+
+        this.updateQueryParam("name", name);
+
+        this.updateQueryParam("secret_key", secretKey);
+
     }
 
     public RegisterS3TargetSpectraS3Request withAutoVerifyFrequencyInDays(final Integer autoVerifyFrequencyInDays) {


### PR DESCRIPTION
**Changes**
- Updating the setting of query parameters that have values (excluding flags with value=null) to use `updateQueryParam` which percent encodes values.