### PR TITLE
Updating broken tests due to 4.0 API changes

### DIFF
--- a/ds3-sdk-integration/src/main/java/com/spectralogic/ds3client/integration/Util.java
+++ b/ds3-sdk-integration/src/main/java/com/spectralogic/ds3client/integration/Util.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
 
 
 public class Util {
@@ -62,6 +63,12 @@ public class Util {
         final int majorVersion = Integer.parseInt(client.getSystemInformationSpectraS3(
                 new GetSystemInformationSpectraS3Request()).getSystemInformationResult().getBuildInformation().getVersion().split("\\.")[0]);
         assumeThat(majorVersion, is(1));
+    }
+
+    public static void assumeVersion3orLess(final Ds3Client client) throws IOException {
+        final int majorVersion = Integer.parseInt(client.getSystemInformationSpectraS3(
+                new GetSystemInformationSpectraS3Request()).getSystemInformationResult().getBuildInformation().getVersion().split("\\.")[0]);
+        assumeTrue(majorVersion <= 3);
     }
 
     public static void loadBookTestData(final Ds3Client client, final String bucketName) throws IOException, URISyntaxException {

--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/Smoke_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/Smoke_Test.java
@@ -143,8 +143,8 @@ public class Smoke_Test {
             assertThat(response.getS3ObjectListResult().getS3Objects().size(), is(4));
             assertTrue(s3ObjectExists(response.getS3ObjectListResult().getS3Objects(), "beowulf.txt"));
 
-            assertThat(response.getPagingTruncated(), is(nullValue()));
-            assertThat(response.getPagingTotalResultCount(), is(nullValue()));
+            assertThat(response.getPagingTruncated(), is(0));
+            assertThat(response.getPagingTotalResultCount(), is(4));
         } finally {
             deleteAllContents(client,bucketName);
         }

--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/UsersAndGroups_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/UsersAndGroups_Test.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.security.SignatureException;
 import java.util.UUID;
 
+import static com.spectralogic.ds3client.integration.Util.assumeVersion3orLess;
 import static com.spectralogic.ds3client.integration.Util.deleteAllContents;
 import static com.spectralogic.ds3client.integration.test.helpers.TempStorageUtil.DEFAULT_USER;
 import static org.hamcrest.Matchers.is;
@@ -546,6 +547,7 @@ public class UsersAndGroups_Test {
 
     @Test
     public void getGroupGroupMembersWithPageStartMarkerUUID() throws IOException, SignatureException {
+        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
 
         final GetGroupMembersSpectraS3Response getGroupMembersSpectraS3Response = client
                 .getGroupMembersSpectraS3(new GetGroupMembersSpectraS3Request()
@@ -556,6 +558,7 @@ public class UsersAndGroups_Test {
 
     @Test
     public void getGroupGroupMembersWithPageStartMarkerString() throws IOException, SignatureException {
+        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
 
         final GetGroupMembersSpectraS3Response getGroupMembersSpectraS3Response = client
                 .getGroupMembersSpectraS3(new GetGroupMembersSpectraS3Request()
@@ -851,6 +854,8 @@ public class UsersAndGroups_Test {
 
     @Test
     public void getBucketAclsWithPageStartMarkerUUID() throws IOException, SignatureException {
+        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
+
         final GetBucketAclsSpectraS3Response getBucketAclsSpectraS3Response = client
                 .getBucketAclsSpectraS3(new GetBucketAclsSpectraS3Request()
                         .withPageStartMarker(UUID.randomUUID()));
@@ -860,6 +865,8 @@ public class UsersAndGroups_Test {
 
     @Test
     public void getBucketAclsWithPageStartMarkerString() throws IOException, SignatureException {
+        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
+
         final GetBucketAclsSpectraS3Response getBucketAclsSpectraS3Response = client
                 .getBucketAclsSpectraS3(new GetBucketAclsSpectraS3Request()
                         .withPageStartMarker(UUID.randomUUID().toString()));
@@ -1182,6 +1189,7 @@ public class UsersAndGroups_Test {
 
     @Test
     public void getDataPolicyAclsWithPageStartMarkerString() throws IOException, SignatureException {
+        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
 
         final GetDataPolicyAclsSpectraS3Response getDataPolicyAclsSpectraS3Response = client
                 .getDataPolicyAclsSpectraS3(new GetDataPolicyAclsSpectraS3Request()
@@ -1192,6 +1200,7 @@ public class UsersAndGroups_Test {
 
     @Test
     public void getDataPolicyAclsWithPageStartMarkerUUID() throws IOException, SignatureException {
+        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
 
         final GetDataPolicyAclsSpectraS3Response getDataPolicyAclsSpectraS3Response = client
                 .getDataPolicyAclsSpectraS3(new GetDataPolicyAclsSpectraS3Request()


### PR DESCRIPTION
**Changes**
-Updating `GetObjects` test with the 4.0 update of paging always enabled
- Created `assumeVersion3orLess` to temporarily not run tests in 4.0 that are failing due to changes in API.  Now the BP throws errors when we pass in a random UUID for page-start-marker optional parameter. The error is currently a 410, but will be updated to 400 or 404 shortly.  Will update tests when BP handling of this scenario is decided and updated.