### PR TITLE
Updated tests in UsersAndGroups to reflect change in 4.0.0 api

### DIFF
--- a/ds3-sdk-integration/src/main/java/com/spectralogic/ds3client/integration/Util.java
+++ b/ds3-sdk-integration/src/main/java/com/spectralogic/ds3client/integration/Util.java
@@ -65,10 +65,10 @@ public class Util {
         assumeThat(majorVersion, is(1));
     }
 
-    public static void assumeVersion3orLess(final Ds3Client client) throws IOException {
+    public static void assumeVersion4orHigher(final Ds3Client client) throws IOException {
         final int majorVersion = Integer.parseInt(client.getSystemInformationSpectraS3(
                 new GetSystemInformationSpectraS3Request()).getSystemInformationResult().getBuildInformation().getVersion().split("\\.")[0]);
-        assumeTrue(majorVersion <= 3);
+        assumeTrue(majorVersion >= 4);
     }
 
     public static void loadBookTestData(final Ds3Client client, final String bucketName) throws IOException, URISyntaxException {

--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/UsersAndGroups_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/UsersAndGroups_Test.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.security.SignatureException;
 import java.util.UUID;
 
-import static com.spectralogic.ds3client.integration.Util.assumeVersion3orLess;
+import static com.spectralogic.ds3client.integration.Util.assumeVersion4orHigher;
 import static com.spectralogic.ds3client.integration.Util.deleteAllContents;
 import static com.spectralogic.ds3client.integration.test.helpers.TempStorageUtil.DEFAULT_USER;
 import static org.hamcrest.Matchers.is;
@@ -181,6 +181,9 @@ public class UsersAndGroups_Test {
 
         final GetUserSpectraS3Response getSpectraResponse = client
                 .getUserSpectraS3(new GetUserSpectraS3Request(spectraUUID));
+
+        assertThat(getSpectraResponse.getSpectraUserResult(), is(notNullValue()));
+
         final ModifyUserSpectraS3Response modifyUserSpectraS3Response = client
                 .modifyUserSpectraS3(new ModifyUserSpectraS3Request(spectraUUID)
                         .withDefaultDataPolicyId(dataPolicyId));
@@ -341,7 +344,7 @@ public class UsersAndGroups_Test {
                     .withPageStartMarker(UUID.randomUUID()));
             fail("The above should not be found and throw exception.");
         } catch (final FailedRequestException e) {
-            assertThat(e.getStatusCode(), is(410));
+            assertThat(e.getStatusCode(), is(404));
         }
     }
 
@@ -547,24 +550,28 @@ public class UsersAndGroups_Test {
 
     @Test
     public void getGroupGroupMembersWithPageStartMarkerUUID() throws IOException, SignatureException {
-        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
+        assumeVersion4orHigher(client);
 
-        final GetGroupMembersSpectraS3Response getGroupMembersSpectraS3Response = client
-                .getGroupMembersSpectraS3(new GetGroupMembersSpectraS3Request()
-                        .withPageStartMarker(UUID.randomUUID()));
+        try {
+            client.getGroupMembersSpectraS3(new GetGroupMembersSpectraS3Request()
+                    .withPageStartMarker(UUID.randomUUID()));
 
-        assertThat(getGroupMembersSpectraS3Response.getGroupMemberListResult(), is(notNullValue()));
+        } catch (final FailedRequestException e) {
+            assertThat(e.getStatusCode(), is(404));
+        }
     }
 
     @Test
     public void getGroupGroupMembersWithPageStartMarkerString() throws IOException, SignatureException {
-        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
+        assumeVersion4orHigher(client);
 
-        final GetGroupMembersSpectraS3Response getGroupMembersSpectraS3Response = client
-                .getGroupMembersSpectraS3(new GetGroupMembersSpectraS3Request()
-                        .withPageStartMarker(UUID.randomUUID().toString()));
+        try {
+            client.getGroupMembersSpectraS3(new GetGroupMembersSpectraS3Request()
+                    .withPageStartMarker(UUID.randomUUID().toString()));
 
-        assertThat(getGroupMembersSpectraS3Response.getGroupMemberListResult(), is(notNullValue()));
+        } catch (final FailedRequestException e) {
+            assertThat(e.getStatusCode(), is(404));
+        }
     }
 
     @Test
@@ -854,24 +861,27 @@ public class UsersAndGroups_Test {
 
     @Test
     public void getBucketAclsWithPageStartMarkerUUID() throws IOException, SignatureException {
-        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
+        assumeVersion4orHigher(client);
 
-        final GetBucketAclsSpectraS3Response getBucketAclsSpectraS3Response = client
-                .getBucketAclsSpectraS3(new GetBucketAclsSpectraS3Request()
-                        .withPageStartMarker(UUID.randomUUID()));
+        try {
+            client.getBucketAclsSpectraS3(new GetBucketAclsSpectraS3Request()
+                    .withPageStartMarker(UUID.randomUUID()));
 
-        assertThat(getBucketAclsSpectraS3Response.getBucketAclListResult(), is(notNullValue()));
+        } catch (final FailedRequestException e) {
+            assertThat(e.getStatusCode(), is(404));
+        }
     }
 
     @Test
     public void getBucketAclsWithPageStartMarkerString() throws IOException, SignatureException {
-        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
+        assumeVersion4orHigher(client);
 
-        final GetBucketAclsSpectraS3Response getBucketAclsSpectraS3Response = client
-                .getBucketAclsSpectraS3(new GetBucketAclsSpectraS3Request()
-                        .withPageStartMarker(UUID.randomUUID().toString()));
-
-        assertThat(getBucketAclsSpectraS3Response.getBucketAclListResult(), is(notNullValue()));
+        try {
+            client.getBucketAclsSpectraS3(new GetBucketAclsSpectraS3Request()
+                    .withPageStartMarker(UUID.randomUUID().toString()));
+        } catch (final FailedRequestException e) {
+            assertThat(e.getStatusCode(), is(404));
+        }
     }
 
     @Test
@@ -1189,24 +1199,26 @@ public class UsersAndGroups_Test {
 
     @Test
     public void getDataPolicyAclsWithPageStartMarkerString() throws IOException, SignatureException {
-        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
+        assumeVersion4orHigher(client);
 
-        final GetDataPolicyAclsSpectraS3Response getDataPolicyAclsSpectraS3Response = client
-                .getDataPolicyAclsSpectraS3(new GetDataPolicyAclsSpectraS3Request()
-                        .withPageStartMarker(UUID.randomUUID().toString()));
-
-        assertThat(getDataPolicyAclsSpectraS3Response.getDataPolicyAclListResult(), is(notNullValue()));
+        try {
+            client.getDataPolicyAclsSpectraS3(new GetDataPolicyAclsSpectraS3Request()
+                    .withPageStartMarker(UUID.randomUUID().toString()));
+        } catch (final FailedRequestException e) {
+            assertThat(e.getStatusCode(), is(404));
+        }
     }
 
     @Test
     public void getDataPolicyAclsWithPageStartMarkerUUID() throws IOException, SignatureException {
-        assumeVersion3orLess(client); //TODO update once 4.0 error code is no longer 410
+        assumeVersion4orHigher(client);
 
-        final GetDataPolicyAclsSpectraS3Response getDataPolicyAclsSpectraS3Response = client
-                .getDataPolicyAclsSpectraS3(new GetDataPolicyAclsSpectraS3Request()
-                        .withPageStartMarker(UUID.randomUUID()));
-
-        assertThat(getDataPolicyAclsSpectraS3Response.getDataPolicyAclListResult(), is(notNullValue()));
+        try {
+            client.getDataPolicyAclsSpectraS3(new GetDataPolicyAclsSpectraS3Request()
+                    .withPageStartMarker(UUID.randomUUID()));
+        } catch (final FailedRequestException e) {
+            assertThat(e.getStatusCode(), is(404));
+        }
     }
 
     @Test

--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/UsersAndGroups_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/UsersAndGroups_Test.java
@@ -555,6 +555,7 @@ public class UsersAndGroups_Test {
         try {
             client.getGroupMembersSpectraS3(new GetGroupMembersSpectraS3Request()
                     .withPageStartMarker(UUID.randomUUID()));
+            fail("The above should not be found and throw exception.");
 
         } catch (final FailedRequestException e) {
             assertThat(e.getStatusCode(), is(404));
@@ -568,6 +569,7 @@ public class UsersAndGroups_Test {
         try {
             client.getGroupMembersSpectraS3(new GetGroupMembersSpectraS3Request()
                     .withPageStartMarker(UUID.randomUUID().toString()));
+            fail("The above should not be found and throw exception.");
 
         } catch (final FailedRequestException e) {
             assertThat(e.getStatusCode(), is(404));
@@ -866,6 +868,7 @@ public class UsersAndGroups_Test {
         try {
             client.getBucketAclsSpectraS3(new GetBucketAclsSpectraS3Request()
                     .withPageStartMarker(UUID.randomUUID()));
+            fail("The above should not be found and throw exception.");
 
         } catch (final FailedRequestException e) {
             assertThat(e.getStatusCode(), is(404));
@@ -879,6 +882,7 @@ public class UsersAndGroups_Test {
         try {
             client.getBucketAclsSpectraS3(new GetBucketAclsSpectraS3Request()
                     .withPageStartMarker(UUID.randomUUID().toString()));
+            fail("The above should not be found and throw exception.");
         } catch (final FailedRequestException e) {
             assertThat(e.getStatusCode(), is(404));
         }
@@ -1204,6 +1208,7 @@ public class UsersAndGroups_Test {
         try {
             client.getDataPolicyAclsSpectraS3(new GetDataPolicyAclsSpectraS3Request()
                     .withPageStartMarker(UUID.randomUUID().toString()));
+            fail("The above should not be found and throw exception.");
         } catch (final FailedRequestException e) {
             assertThat(e.getStatusCode(), is(404));
         }
@@ -1216,6 +1221,7 @@ public class UsersAndGroups_Test {
         try {
             client.getDataPolicyAclsSpectraS3(new GetDataPolicyAclsSpectraS3Request()
                     .withPageStartMarker(UUID.randomUUID()));
+            fail("The above should not be found and throw exception.");
         } catch (final FailedRequestException e) {
             assertThat(e.getStatusCode(), is(404));
         }


### PR DESCRIPTION
**Changes**
Updated tests in `UsersAndGroups_Test` to reflect change from 3.5 -> 4.0 where creating a command with optional `PageStartMarker` pointing to a non-existent UUID now returns a 404 (where previously it did not error).