### PR TITLE
SA-193: Fixed request payloads with IDs payload

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
@@ -39,6 +39,7 @@ public interface Ds3Client extends Closeable {
 
     PutFolderResponse putFolder(final PutFolderRequest request)
             throws IOException;
+
     
     
     AbortMultiPartUploadResponse abortMultiPartUpload(final AbortMultiPartUploadRequest request)

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/interfaces/AbstractIdsPayloadRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/interfaces/AbstractIdsPayloadRequest.java
@@ -1,0 +1,54 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.commands.interfaces;
+
+import com.spectralogic.ds3client.models.requestpayloads.Ids;
+import com.spectralogic.ds3client.serializer.XmlOutput;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.List;
+
+/**
+ * Abstract class that handles request payload of ids, in format:
+ * <ids><id>id1</id><id>id2</id>...</ids>
+ */
+public abstract class AbstractIdsPayloadRequest extends AbstractRequest {
+
+    private final List<String> ids;
+    private long size;
+
+    public AbstractIdsPayloadRequest(final List<String> ids) {
+        super();
+        this.ids = ids;
+    }
+
+    @Override
+    public InputStream getStream() {
+        final Ids requestPayload = new Ids(ids);
+        final String xmlOutput = XmlOutput.toXml(requestPayload);
+        final byte[] stringBytes = xmlOutput.getBytes(Charset.forName("UTF-8"));
+        this.size = stringBytes.length;
+
+        return new ByteArrayInputStream(stringBytes);
+    }
+
+    @Override
+    public long getSize() {
+        return this.size;
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ClearSuspectBlobAzureTargetsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ClearSuspectBlobAzureTargetsSpectraS3Request.java
@@ -16,10 +16,12 @@
 // This code is auto-generated, do not modify
 package com.spectralogic.ds3client.commands.spectrads3;
 
+import com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest;
 import com.spectralogic.ds3client.networking.HttpVerb;
-import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
 
-public class ClearSuspectBlobAzureTargetsSpectraS3Request extends AbstractRequest {
+import java.util.List;
+
+public class ClearSuspectBlobAzureTargetsSpectraS3Request extends AbstractIdsPayloadRequest {
 
     // Variables
     
@@ -28,8 +30,8 @@ public class ClearSuspectBlobAzureTargetsSpectraS3Request extends AbstractReques
     // Constructor
     
     
-    public ClearSuspectBlobAzureTargetsSpectraS3Request() {
-        
+    public ClearSuspectBlobAzureTargetsSpectraS3Request(final List<String> ids) {
+        super(ids);
     }
 
     public ClearSuspectBlobAzureTargetsSpectraS3Request withForce(final boolean force) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ClearSuspectBlobAzureTargetsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ClearSuspectBlobAzureTargetsSpectraS3Request.java
@@ -16,8 +16,8 @@
 // This code is auto-generated, do not modify
 package com.spectralogic.ds3client.commands.spectrads3;
 
-import com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest;
 import com.spectralogic.ds3client.networking.HttpVerb;
+import com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest;
 
 import java.util.List;
 
@@ -29,9 +29,9 @@ public class ClearSuspectBlobAzureTargetsSpectraS3Request extends AbstractIdsPay
 
     // Constructor
     
-    
     public ClearSuspectBlobAzureTargetsSpectraS3Request(final List<String> ids) {
         super(ids);
+        
     }
 
     public ClearSuspectBlobAzureTargetsSpectraS3Request withForce(final boolean force) {

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ClearSuspectBlobPoolsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ClearSuspectBlobPoolsSpectraS3Request.java
@@ -17,9 +17,11 @@
 package com.spectralogic.ds3client.commands.spectrads3;
 
 import com.spectralogic.ds3client.networking.HttpVerb;
-import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
+import com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest;
 
-public class ClearSuspectBlobPoolsSpectraS3Request extends AbstractRequest {
+import java.util.List;
+
+public class ClearSuspectBlobPoolsSpectraS3Request extends AbstractIdsPayloadRequest {
 
     // Variables
     
@@ -27,8 +29,8 @@ public class ClearSuspectBlobPoolsSpectraS3Request extends AbstractRequest {
 
     // Constructor
     
-    
-    public ClearSuspectBlobPoolsSpectraS3Request() {
+    public ClearSuspectBlobPoolsSpectraS3Request(final List<String> ids) {
+        super(ids);
         
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ClearSuspectBlobS3TargetsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ClearSuspectBlobS3TargetsSpectraS3Request.java
@@ -17,9 +17,11 @@
 package com.spectralogic.ds3client.commands.spectrads3;
 
 import com.spectralogic.ds3client.networking.HttpVerb;
-import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
+import com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest;
 
-public class ClearSuspectBlobS3TargetsSpectraS3Request extends AbstractRequest {
+import java.util.List;
+
+public class ClearSuspectBlobS3TargetsSpectraS3Request extends AbstractIdsPayloadRequest {
 
     // Variables
     
@@ -27,8 +29,8 @@ public class ClearSuspectBlobS3TargetsSpectraS3Request extends AbstractRequest {
 
     // Constructor
     
-    
-    public ClearSuspectBlobS3TargetsSpectraS3Request() {
+    public ClearSuspectBlobS3TargetsSpectraS3Request(final List<String> ids) {
+        super(ids);
         
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ClearSuspectBlobTapesSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/ClearSuspectBlobTapesSpectraS3Request.java
@@ -17,9 +17,11 @@
 package com.spectralogic.ds3client.commands.spectrads3;
 
 import com.spectralogic.ds3client.networking.HttpVerb;
-import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
+import com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest;
 
-public class ClearSuspectBlobTapesSpectraS3Request extends AbstractRequest {
+import java.util.List;
+
+public class ClearSuspectBlobTapesSpectraS3Request extends AbstractIdsPayloadRequest {
 
     // Variables
     
@@ -27,8 +29,8 @@ public class ClearSuspectBlobTapesSpectraS3Request extends AbstractRequest {
 
     // Constructor
     
-    
-    public ClearSuspectBlobTapesSpectraS3Request() {
+    public ClearSuspectBlobTapesSpectraS3Request(final List<String> ids) {
+        super(ids);
         
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/GetPoolsSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/GetPoolsSpectraS3Request.java
@@ -33,6 +33,8 @@ public class GetPoolsSpectraS3Request extends AbstractPaginationRequest {
 
     private String bucketId;
 
+    private String guid;
+
     private PoolHealth health;
 
     private boolean lastPage;
@@ -74,6 +76,13 @@ public class GetPoolsSpectraS3Request extends AbstractPaginationRequest {
     public GetPoolsSpectraS3Request withBucketId(final String bucketId) {
         this.bucketId = bucketId;
         this.updateQueryParam("bucket_id", bucketId);
+        return this;
+    }
+
+
+    public GetPoolsSpectraS3Request withGuid(final String guid) {
+        this.guid = guid;
+        this.updateQueryParam("guid", guid);
         return this;
     }
 
@@ -205,6 +214,11 @@ public class GetPoolsSpectraS3Request extends AbstractPaginationRequest {
 
     public String getBucketId() {
         return this.bucketId;
+    }
+
+
+    public String getGuid() {
+        return this.guid;
     }
 
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request.java
@@ -17,9 +17,11 @@
 package com.spectralogic.ds3client.commands.spectrads3;
 
 import com.spectralogic.ds3client.networking.HttpVerb;
-import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
+import com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest;
 
-public class MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request extends AbstractRequest {
+import java.util.List;
+
+public class MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request extends AbstractIdsPayloadRequest {
 
     // Variables
     
@@ -27,8 +29,8 @@ public class MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request extends Abstr
 
     // Constructor
     
-    
-    public MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request() {
+    public MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(final List<String> ids) {
+        super(ids);
         
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request.java
@@ -17,9 +17,11 @@
 package com.spectralogic.ds3client.commands.spectrads3;
 
 import com.spectralogic.ds3client.networking.HttpVerb;
-import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
+import com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest;
 
-public class MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request extends AbstractRequest {
+import java.util.List;
+
+public class MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request extends AbstractIdsPayloadRequest {
 
     // Variables
     
@@ -27,8 +29,8 @@ public class MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request extends Abstrac
 
     // Constructor
     
-    
-    public MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request() {
+    public MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(final List<String> ids) {
+        super(ids);
         
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/MarkSuspectBlobPoolsAsDegradedSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/MarkSuspectBlobPoolsAsDegradedSpectraS3Request.java
@@ -17,9 +17,11 @@
 package com.spectralogic.ds3client.commands.spectrads3;
 
 import com.spectralogic.ds3client.networking.HttpVerb;
-import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
+import com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest;
 
-public class MarkSuspectBlobPoolsAsDegradedSpectraS3Request extends AbstractRequest {
+import java.util.List;
+
+public class MarkSuspectBlobPoolsAsDegradedSpectraS3Request extends AbstractIdsPayloadRequest {
 
     // Variables
     
@@ -27,8 +29,8 @@ public class MarkSuspectBlobPoolsAsDegradedSpectraS3Request extends AbstractRequ
 
     // Constructor
     
-    
-    public MarkSuspectBlobPoolsAsDegradedSpectraS3Request() {
+    public MarkSuspectBlobPoolsAsDegradedSpectraS3Request(final List<String> ids) {
+        super(ids);
         
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request.java
@@ -17,9 +17,11 @@
 package com.spectralogic.ds3client.commands.spectrads3;
 
 import com.spectralogic.ds3client.networking.HttpVerb;
-import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
+import com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest;
 
-public class MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request extends AbstractRequest {
+import java.util.List;
+
+public class MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request extends AbstractIdsPayloadRequest {
 
     // Variables
     
@@ -27,8 +29,8 @@ public class MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request extends Abstract
 
     // Constructor
     
-    
-    public MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request() {
+    public MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(final List<String> ids) {
+        super(ids);
         
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/MarkSuspectBlobTapesAsDegradedSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/MarkSuspectBlobTapesAsDegradedSpectraS3Request.java
@@ -17,9 +17,11 @@
 package com.spectralogic.ds3client.commands.spectrads3;
 
 import com.spectralogic.ds3client.networking.HttpVerb;
-import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
+import com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest;
 
-public class MarkSuspectBlobTapesAsDegradedSpectraS3Request extends AbstractRequest {
+import java.util.List;
+
+public class MarkSuspectBlobTapesAsDegradedSpectraS3Request extends AbstractIdsPayloadRequest {
 
     // Variables
     
@@ -27,8 +29,8 @@ public class MarkSuspectBlobTapesAsDegradedSpectraS3Request extends AbstractRequ
 
     // Constructor
     
-    
-    public MarkSuspectBlobTapesAsDegradedSpectraS3Request() {
+    public MarkSuspectBlobTapesAsDegradedSpectraS3Request(final List<String> ids) {
+        super(ids);
         
     }
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/TapeDriveType.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/TapeDriveType.java
@@ -23,5 +23,6 @@ public enum TapeDriveType {
     LTO7,
     LTO8,
     TS1140,
-    TS1150
+    TS1150,
+    TS1155
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/requestpayloads/Ids.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/models/requestpayloads/Ids.java
@@ -1,0 +1,44 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.models.requestpayloads;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+
+import java.util.List;
+
+/**
+ * Represents a request payload that is used by {@link com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest}
+ * and is used to marshal to xml a list of IDs in proper format
+ */
+public class Ids {
+
+    @JsonProperty("Id")
+    @JacksonXmlElementWrapper( useWrapping = false)
+    private List<String> ids;
+
+    public Ids(final List<String> ids) {
+        this.ids = ids;
+    }
+
+    public List<String> getIds() {
+        return ids;
+    }
+
+    public void setIds(final List<String> ids) {
+        this.ids = ids;
+    }
+}

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
@@ -1143,4 +1143,22 @@ public class Ds3Client_Test {
     public void createFolderWithNoSlash() throws IOException {
         new PutFolderRequest("BucketName", "FolderNameNoSlash", UUID.randomUUID());
     }
+
+    @Test
+    public void clearSuspectBlobAzureTargetsSpectraS3Test() throws IOException {
+        final String expectedRequestContent = "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>";
+
+        final List<String> ids = new ArrayList<>();
+        ids.add("id1");
+        ids.add("id2");
+        ids.add("id3");
+
+        final Map<String, String> queryParams = new HashMap<>();
+
+        MockNetwork
+                .expecting(HttpVerb.DELETE, "/_rest_/suspect_blob_azure_target", queryParams, expectedRequestContent)
+                .returning(204, "")
+                .asClient()
+                .clearSuspectBlobAzureTargetsSpectraS3(new ClearSuspectBlobAzureTargetsSpectraS3Request(ids));
+    }
 }


### PR DESCRIPTION
**Changes**
- Added new abstract class which handles creation of stream payload of ids from list of ids `AbstractIdsPayloadRequest`
- Updated 9 commands to use new request payload types
- Added unit test to verify new request payload is marshaled as expected
- Re-generated SDK with newest 4.0.0 API which has minor changes not related to SA-193