### PR TITLE
Fix for https://jira.spectralogic.com/browse/JSDK-245 Null Pointer exception for get system info

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/utils/PropertyUtils.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/utils/PropertyUtils.java
@@ -15,7 +15,6 @@
 
 package com.spectralogic.ds3client.utils;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/utils/PropertyUtils.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/utils/PropertyUtils.java
@@ -47,13 +47,18 @@ public final class PropertyUtils {
         try (final InputStream propertiesStream = PropertyUtils.class.getClassLoader().getResourceAsStream(PROPERTIES_FILE_NAME)) {
             if (propertiesStream != null) {
                 properties.load(propertiesStream);
-                final String versionFromPropFile = properties.get(SDK_VERSION_PROPERTY_NAME).toString();
-                if (!Guard.isStringNullOrEmpty(versionFromPropFile)) {
-                    versionProperty.set(versionFromPropFile);
+                final Object versionPropertyObject = properties.get(SDK_VERSION_PROPERTY_NAME);
+
+                if (versionPropertyObject != null) {
+                    final String versionFromPropFile = properties.get(SDK_VERSION_PROPERTY_NAME).toString();
+
+                    if ( ! Guard.isStringNullOrEmpty(versionFromPropFile)) {
+                        versionProperty.set(versionFromPropFile);
+                    }
                 }
             }
-        } catch (final IOException e) {
-            LOG.warn("Could not read properties file.", e);
+        } catch (final Throwable t) {
+            LOG.warn("Could not read properties file.", t);
         }
 
         return versionProperty.get();


### PR DESCRIPTION

Not exactly sure why we got the NPE, as extracting the files after pulling down the 'all' jar shows the .properties file where we expect it with the right contents, so...