### PR TITLE
JSDK-248 Correcting issue where FileObjectGetter does not respect symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ atlassian-ide-plugin.xml
 bin/
 *.log
 *.rc
+.DS_Store

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/FileObjectGetter.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/FileObjectGetter.java
@@ -44,7 +44,7 @@ public class FileObjectGetter implements ObjectChannelBuilder {
         final Path objectPath = this.root.resolve(key);
         final Path parentPath = objectPath.getParent();
         if (parentPath != null) {
-            Files.createDirectories(parentPath);
+            Files.createDirectories(FileUtils.resolveForSymbolic(parentPath));
         }
 
         if ( ! FileUtils.isTransferablePath(objectPath)) {


### PR DESCRIPTION
Files.createDirectories fails with a FileAlreadyExists exception if there is a non-directory file in the provided path. This includes symbolic links. By including the FileUtils.resolveForSymbolic() we allow writing to paths that contain symbolic links.