### PR TITLE
SA-210: Ensuring streams and channels are not null

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 public interface Ds3Client extends Closeable {
 
     ConnectionDetails getConnectionDetails();
+
     
     
     AbortMultiPartUploadResponse abortMultiPartUpload(final AbortMultiPartUploadRequest request)

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/GetObjectRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/GetObjectRequest.java
@@ -29,6 +29,8 @@ import java.util.Collection;
 import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
 import java.util.UUID;
 import com.google.common.net.UrlEscapers;
+import javax.annotation.Nonnull;
+import com.google.common.base.Preconditions;
 import com.spectralogic.ds3client.models.ChecksumType;
 
 public class GetObjectRequest extends AbstractRequest {
@@ -52,7 +54,8 @@ public class GetObjectRequest extends AbstractRequest {
     
     /** @deprecated use {@link #GetObjectRequest(String, String, WritableByteChannel, UUID, long)} instead */
     @Deprecated
-    public GetObjectRequest(final String bucketName, final String objectName, final WritableByteChannel channel) {
+    public GetObjectRequest(final String bucketName, final String objectName, @Nonnull final WritableByteChannel channel) {
+        Preconditions.checkNotNull(channel, "Channel may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.channel = channel;
@@ -61,7 +64,8 @@ public class GetObjectRequest extends AbstractRequest {
     }
 
     
-    public GetObjectRequest(final String bucketName, final String objectName, final WritableByteChannel channel, final UUID job, final long offset) {
+    public GetObjectRequest(final String bucketName, final String objectName, @Nonnull final WritableByteChannel channel, final UUID job, final long offset) {
+        Preconditions.checkNotNull(channel, "Channel may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.job = job.toString();
@@ -76,7 +80,8 @@ public class GetObjectRequest extends AbstractRequest {
     }
 
     
-    public GetObjectRequest(final String bucketName, final String objectName, final WritableByteChannel channel, final String job, final long offset) {
+    public GetObjectRequest(final String bucketName, final String objectName, @Nonnull final WritableByteChannel channel, final String job, final long offset) {
+        Preconditions.checkNotNull(channel, "Channel may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.job = job;
@@ -91,7 +96,8 @@ public class GetObjectRequest extends AbstractRequest {
     }
 
     
-    public GetObjectRequest(final String bucketName, final String objectName, final UUID job, final long offset, final OutputStream stream) {
+    public GetObjectRequest(final String bucketName, final String objectName, final UUID job, final long offset, @Nonnull final OutputStream stream) {
+        Preconditions.checkNotNull(stream, "Stream may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.job = job.toString();
@@ -106,7 +112,8 @@ public class GetObjectRequest extends AbstractRequest {
     }
 
     
-    public GetObjectRequest(final String bucketName, final String objectName, final String job, final long offset, final OutputStream stream) {
+    public GetObjectRequest(final String bucketName, final String objectName, final String job, final long offset, @Nonnull final OutputStream stream) {
+        Preconditions.checkNotNull(stream, "Stream may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.job = job;

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.java
@@ -20,6 +20,8 @@ import com.spectralogic.ds3client.networking.HttpVerb;
 import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
 import java.util.UUID;
 import com.google.common.net.UrlEscapers;
+import javax.annotation.Nonnull;
+import com.google.common.base.Preconditions;
 import com.spectralogic.ds3client.utils.SeekableByteChannelInputStream;
 import java.nio.channels.SeekableByteChannel;
 import java.io.InputStream;
@@ -45,7 +47,8 @@ public class PutMultiPartUploadPartRequest extends AbstractRequest {
     // Constructor
     
     
-    public PutMultiPartUploadPartRequest(final String bucketName, final String objectName, final SeekableByteChannel channel, final int partNumber, final long size, final UUID uploadId) {
+    public PutMultiPartUploadPartRequest(final String bucketName, final String objectName, @Nonnull final SeekableByteChannel channel, final int partNumber, final long size, final UUID uploadId) {
+        Preconditions.checkNotNull(channel, "Channel may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.partNumber = partNumber;
@@ -61,7 +64,8 @@ public class PutMultiPartUploadPartRequest extends AbstractRequest {
     }
 
     
-    public PutMultiPartUploadPartRequest(final String bucketName, final String objectName, final SeekableByteChannel channel, final int partNumber, final long size, final String uploadId) {
+    public PutMultiPartUploadPartRequest(final String bucketName, final String objectName, @Nonnull final SeekableByteChannel channel, final int partNumber, final long size, final String uploadId) {
+        Preconditions.checkNotNull(channel, "Channel may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.partNumber = partNumber;
@@ -77,7 +81,8 @@ public class PutMultiPartUploadPartRequest extends AbstractRequest {
     }
 
     
-    public PutMultiPartUploadPartRequest(final String bucketName, final String objectName, final int partNumber, final long size, final InputStream stream, final UUID uploadId) {
+    public PutMultiPartUploadPartRequest(final String bucketName, final String objectName, final int partNumber, final long size, @Nonnull final InputStream stream, final UUID uploadId) {
+        Preconditions.checkNotNull(stream, "Stream may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.partNumber = partNumber;
@@ -92,7 +97,8 @@ public class PutMultiPartUploadPartRequest extends AbstractRequest {
     }
 
     
-    public PutMultiPartUploadPartRequest(final String bucketName, final String objectName, final int partNumber, final long size, final InputStream stream, final String uploadId) {
+    public PutMultiPartUploadPartRequest(final String bucketName, final String objectName, final int partNumber, final long size, @Nonnull final InputStream stream, final String uploadId) {
+        Preconditions.checkNotNull(stream, "Stream may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.partNumber = partNumber;

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/PutObjectRequest.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/PutObjectRequest.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
 import java.util.UUID;
 import com.google.common.net.UrlEscapers;
+import javax.annotation.Nonnull;
+import com.google.common.base.Preconditions;
 import com.spectralogic.ds3client.models.ChecksumType;
 public class PutObjectRequest extends AbstractRequest {
 
@@ -53,7 +55,8 @@ public class PutObjectRequest extends AbstractRequest {
     
     /** @deprecated use {@link #PutObjectRequest(String, String, SeekableByteChannel, UUID, long, long)} instead */
     @Deprecated
-    public PutObjectRequest(final String bucketName, final String objectName, final SeekableByteChannel channel, final long size) {
+    public PutObjectRequest(final String bucketName, final String objectName, @Nonnull final SeekableByteChannel channel, final long size) {
+        Preconditions.checkNotNull(channel, "Channel may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.size = size;
@@ -64,7 +67,8 @@ public class PutObjectRequest extends AbstractRequest {
     }
 
     
-    public PutObjectRequest(final String bucketName, final String objectName, final SeekableByteChannel channel, final UUID job, final long offset, final long size) {
+    public PutObjectRequest(final String bucketName, final String objectName, @Nonnull final SeekableByteChannel channel, final UUID job, final long offset, final long size) {
+        Preconditions.checkNotNull(channel, "Channel may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.size = size;
@@ -81,7 +85,8 @@ public class PutObjectRequest extends AbstractRequest {
     }
 
     
-    public PutObjectRequest(final String bucketName, final String objectName, final SeekableByteChannel channel, final String job, final long offset, final long size) {
+    public PutObjectRequest(final String bucketName, final String objectName, @Nonnull final SeekableByteChannel channel, final String job, final long offset, final long size) {
+        Preconditions.checkNotNull(channel, "Channel may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.size = size;
@@ -98,7 +103,8 @@ public class PutObjectRequest extends AbstractRequest {
     }
 
     
-    public PutObjectRequest(final String bucketName, final String objectName, final UUID job, final long offset, final long size, final InputStream stream) {
+    public PutObjectRequest(final String bucketName, final String objectName, final UUID job, final long offset, final long size, @Nonnull final InputStream stream) {
+        Preconditions.checkNotNull(stream, "Stream may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.size = size;
@@ -114,7 +120,8 @@ public class PutObjectRequest extends AbstractRequest {
     }
 
     
-    public PutObjectRequest(final String bucketName, final String objectName, final String job, final long offset, final long size, final InputStream stream) {
+    public PutObjectRequest(final String bucketName, final String objectName, final String job, final long offset, final long size, @Nonnull final InputStream stream) {
+        Preconditions.checkNotNull(stream, "Stream may not be null.");
         this.bucketName = bucketName;
         this.objectName = objectName;
         this.size = size;

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutDs3TargetFailureNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutDs3TargetFailureNotificationRegistrationSpectraS3Request.java
@@ -35,7 +35,6 @@ public class PutDs3TargetFailureNotificationRegistrationSpectraS3Request extends
     
     public PutDs3TargetFailureNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutJobCompletedNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutJobCompletedNotificationRegistrationSpectraS3Request.java
@@ -38,7 +38,6 @@ public class PutJobCompletedNotificationRegistrationSpectraS3Request extends Abs
     
     public PutJobCompletedNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutJobCreatedNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutJobCreatedNotificationRegistrationSpectraS3Request.java
@@ -35,7 +35,6 @@ public class PutJobCreatedNotificationRegistrationSpectraS3Request extends Abstr
     
     public PutJobCreatedNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutJobCreationFailedNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutJobCreationFailedNotificationRegistrationSpectraS3Request.java
@@ -35,7 +35,6 @@ public class PutJobCreationFailedNotificationRegistrationSpectraS3Request extend
     
     public PutJobCreationFailedNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutObjectCachedNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutObjectCachedNotificationRegistrationSpectraS3Request.java
@@ -38,7 +38,6 @@ public class PutObjectCachedNotificationRegistrationSpectraS3Request extends Abs
     
     public PutObjectCachedNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutObjectLostNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutObjectLostNotificationRegistrationSpectraS3Request.java
@@ -35,7 +35,6 @@ public class PutObjectLostNotificationRegistrationSpectraS3Request extends Abstr
     
     public PutObjectLostNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutObjectPersistedNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutObjectPersistedNotificationRegistrationSpectraS3Request.java
@@ -38,7 +38,6 @@ public class PutObjectPersistedNotificationRegistrationSpectraS3Request extends 
     
     public PutObjectPersistedNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutPoolFailureNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutPoolFailureNotificationRegistrationSpectraS3Request.java
@@ -35,7 +35,6 @@ public class PutPoolFailureNotificationRegistrationSpectraS3Request extends Abst
     
     public PutPoolFailureNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutStorageDomainFailureNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutStorageDomainFailureNotificationRegistrationSpectraS3Request.java
@@ -35,7 +35,6 @@ public class PutStorageDomainFailureNotificationRegistrationSpectraS3Request ext
     
     public PutStorageDomainFailureNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutSystemFailureNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutSystemFailureNotificationRegistrationSpectraS3Request.java
@@ -35,7 +35,6 @@ public class PutSystemFailureNotificationRegistrationSpectraS3Request extends Ab
     
     public PutSystemFailureNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutTapeFailureNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutTapeFailureNotificationRegistrationSpectraS3Request.java
@@ -35,7 +35,6 @@ public class PutTapeFailureNotificationRegistrationSpectraS3Request extends Abst
     
     public PutTapeFailureNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutTapePartitionFailureNotificationRegistrationSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/notifications/PutTapePartitionFailureNotificationRegistrationSpectraS3Request.java
@@ -35,7 +35,6 @@ public class PutTapePartitionFailureNotificationRegistrationSpectraS3Request ext
     
     public PutTapePartitionFailureNotificationRegistrationSpectraS3Request(final String notificationEndPoint) {
         super(notificationEndPoint);
-
         
 
     }


### PR DESCRIPTION
**Changes**
- Added `Nonnull` annotation to channel and stream parameters to request handler constructors.
- Added precondition to verify channels and streams are non-null in request handler constructors.