### PR TITLE
JSDK-257: Negative tests for null streams and channels

### DIFF
--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
@@ -1554,4 +1554,74 @@ public class Ds3Client_Test {
                 .asClient()
                 .getBlobsOnDs3TargetSpectraS3(new GetBlobsOnDs3TargetSpectraS3Request(target));
     }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void getObjectNullChannelDeprecatedConstructorTest() {
+        new GetObjectRequest("BucketName", "ObjectName", null);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void getObjectNullChannelUuidConstructorTest() {
+        new GetObjectRequest("BucketName", "ObjectName", null, UUID.randomUUID(), 0);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void getObjectNullChannelStringConstructorTest() {
+        new GetObjectRequest("BucketName", "ObjectName", null, "JobId", 0);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void getObjectNullStreamUuidConstructorTest() {
+        new GetObjectRequest("BucketName", "ObjectName", UUID.randomUUID(), 0, null);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void getObjectNullStreamStringConstructorTest() {
+        new GetObjectRequest("BucketName", "ObjectName", "JobId", 0, null);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void putObjectDeprecatedConstructorTest() {
+        new PutObjectRequest("BucketName", "ObjectName", null, 0);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void putObjectNullChannelUuidConstructorTest() {
+        new PutObjectRequest("BucketName", "ObjectName", null, UUID.randomUUID(),0, 0);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void putObjectNullChannelStringConstructorTest() {
+        new PutObjectRequest("BucketName", "ObjectName", null, "JobId",0, 0);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void putObjectNullStreamUuidConstructorTest() {
+        new PutObjectRequest("BucketName", "ObjectName", UUID.randomUUID(), 0, 0, null);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void putObjectNullStreamStringConstructorTest() {
+        new PutObjectRequest("BucketName", "ObjectName", "JobId", 0, 0, null);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void putMultiPartUploadNullChannelUuidConstructorTest() {
+        new PutMultiPartUploadPartRequest("BucketName", "ObjectName", null, 0, 0, UUID.randomUUID());
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void putMultiPartUploadNullChannelStringConstructorTest() {
+        new PutMultiPartUploadPartRequest("BucketName", "ObjectName", null, 0, 0, "UploadId");
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void putMultiPartUploadNullStreamUuidConstructorTest() {
+        new PutMultiPartUploadPartRequest("BucketName", "ObjectName", 0, 0, null, UUID.randomUUID());
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void putMultiPartUploadNullStreamStringConstructorTest() {
+        new PutMultiPartUploadPartRequest("BucketName", "ObjectName", 0, 0, null, "UploadId");
+    }
 }

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
@@ -51,6 +51,7 @@ import java.util.regex.Pattern;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.fail;
 
 public class Ds3Client_Test {
     private static final UUID MASTER_OBJECT_LIST_JOB_ID = UUID.fromString("1a85e743-ec8f-4789-afec-97e587a26936");
@@ -1555,73 +1556,185 @@ public class Ds3Client_Test {
                 .getBlobsOnDs3TargetSpectraS3(new GetBlobsOnDs3TargetSpectraS3Request(target));
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void getObjectNullChannelDeprecatedConstructorTest() {
-        new GetObjectRequest("BucketName", "ObjectName", null);
+        try {
+            new GetObjectRequest("BucketName", "ObjectName", null);
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Channel may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/GetObjectRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void getObjectNullChannelUuidConstructorTest() {
-        new GetObjectRequest("BucketName", "ObjectName", null, UUID.randomUUID(), 0);
+        try {
+            new GetObjectRequest("BucketName", "ObjectName", null, UUID.randomUUID(), 0);
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Channel may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/GetObjectRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void getObjectNullChannelStringConstructorTest() {
-        new GetObjectRequest("BucketName", "ObjectName", null, "JobId", 0);
+        try {
+            new GetObjectRequest("BucketName", "ObjectName", null, "JobId", 0);
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Channel may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/GetObjectRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void getObjectNullStreamUuidConstructorTest() {
-        new GetObjectRequest("BucketName", "ObjectName", UUID.randomUUID(), 0, null);
+        try {
+            new GetObjectRequest("BucketName", "ObjectName", UUID.randomUUID(), 0, null);
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Stream may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/GetObjectRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void getObjectNullStreamStringConstructorTest() {
-        new GetObjectRequest("BucketName", "ObjectName", "JobId", 0, null);
+        try {
+            new GetObjectRequest("BucketName", "ObjectName", "JobId", 0, null);
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Stream may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/GetObjectRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void putObjectDeprecatedConstructorTest() {
-        new PutObjectRequest("BucketName", "ObjectName", null, 0);
+        try {
+            new PutObjectRequest("BucketName", "ObjectName", null, 0);
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Channel may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/PutObjectRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void putObjectNullChannelUuidConstructorTest() {
-        new PutObjectRequest("BucketName", "ObjectName", null, UUID.randomUUID(),0, 0);
+        try {
+            new PutObjectRequest("BucketName", "ObjectName", null, UUID.randomUUID(),0, 0);
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Channel may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/PutObjectRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void putObjectNullChannelStringConstructorTest() {
-        new PutObjectRequest("BucketName", "ObjectName", null, "JobId",0, 0);
+        try {
+            new PutObjectRequest("BucketName", "ObjectName", null, "JobId",0, 0);
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Channel may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/PutObjectRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void putObjectNullStreamUuidConstructorTest() {
-        new PutObjectRequest("BucketName", "ObjectName", UUID.randomUUID(), 0, 0, null);
+        try {
+            new PutObjectRequest("BucketName", "ObjectName", UUID.randomUUID(), 0, 0, null);
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Stream may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/PutObjectRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void putObjectNullStreamStringConstructorTest() {
-        new PutObjectRequest("BucketName", "ObjectName", "JobId", 0, 0, null);
+        try {
+            new PutObjectRequest("BucketName", "ObjectName", "JobId", 0, 0, null);
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Stream may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/PutObjectRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void putMultiPartUploadNullChannelUuidConstructorTest() {
-        new PutMultiPartUploadPartRequest("BucketName", "ObjectName", null, 0, 0, UUID.randomUUID());
+        try {
+            new PutMultiPartUploadPartRequest("BucketName", "ObjectName", null, 0, 0, UUID.randomUUID());
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Channel may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void putMultiPartUploadNullChannelStringConstructorTest() {
-        new PutMultiPartUploadPartRequest("BucketName", "ObjectName", null, 0, 0, "UploadId");
+        try {
+            new PutMultiPartUploadPartRequest("BucketName", "ObjectName", null, 0, 0, "UploadId");
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Channel may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void putMultiPartUploadNullStreamUuidConstructorTest() {
-        new PutMultiPartUploadPartRequest("BucketName", "ObjectName", 0, 0, null, UUID.randomUUID());
+        try {
+            new PutMultiPartUploadPartRequest("BucketName", "ObjectName", 0, 0, null, UUID.randomUUID());
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Stream may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.<init> must not be null"));
+        }
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void putMultiPartUploadNullStreamStringConstructorTest() {
-        new PutMultiPartUploadPartRequest("BucketName", "ObjectName", 0, 0, null, "UploadId");
+        try {
+            new PutMultiPartUploadPartRequest("BucketName", "ObjectName", 0, 0, null, "UploadId");
+            fail();
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), is("Stream may not be null."));
+        } catch (final IllegalArgumentException e) {
+            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
+            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.<init> must not be null"));
+        }
     }
 }

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
@@ -1558,183 +1558,97 @@ public class Ds3Client_Test {
 
     @Test
     public void getObjectNullChannelDeprecatedConstructorTest() {
-        try {
-            new GetObjectRequest("BucketName", "ObjectName", null);
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Channel may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/GetObjectRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Channel",
+                () -> new GetObjectRequest("BucketName", "ObjectName", null));
     }
 
     @Test
     public void getObjectNullChannelUuidConstructorTest() {
-        try {
-            new GetObjectRequest("BucketName", "ObjectName", null, UUID.randomUUID(), 0);
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Channel may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/GetObjectRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Channel",
+                () -> new GetObjectRequest("BucketName", "ObjectName", null, UUID.randomUUID(), 0));
     }
 
     @Test
     public void getObjectNullChannelStringConstructorTest() {
-        try {
-            new GetObjectRequest("BucketName", "ObjectName", null, "JobId", 0);
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Channel may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/GetObjectRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Channel",
+                () -> new GetObjectRequest("BucketName", "ObjectName", null, "JobId", 0));
     }
 
     @Test
     public void getObjectNullStreamUuidConstructorTest() {
-        try {
-            new GetObjectRequest("BucketName", "ObjectName", UUID.randomUUID(), 0, null);
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Stream may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/GetObjectRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Stream",
+                () -> new GetObjectRequest("BucketName", "ObjectName", UUID.randomUUID(), 0, null));
     }
 
     @Test
     public void getObjectNullStreamStringConstructorTest() {
-        try {
-            new GetObjectRequest("BucketName", "ObjectName", "JobId", 0, null);
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Stream may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/GetObjectRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Stream",
+                () -> new GetObjectRequest("BucketName", "ObjectName", "JobId", 0, null));
     }
 
     @Test
     public void putObjectDeprecatedConstructorTest() {
-        try {
-            new PutObjectRequest("BucketName", "ObjectName", null, 0);
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Channel may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/PutObjectRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Channel",
+                () -> new PutObjectRequest("BucketName", "ObjectName", null, 0));
     }
 
     @Test
     public void putObjectNullChannelUuidConstructorTest() {
-        try {
-            new PutObjectRequest("BucketName", "ObjectName", null, UUID.randomUUID(),0, 0);
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Channel may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/PutObjectRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Channel",
+                () -> new PutObjectRequest("BucketName", "ObjectName", null, UUID.randomUUID(),0, 0));
     }
 
     @Test
     public void putObjectNullChannelStringConstructorTest() {
-        try {
-            new PutObjectRequest("BucketName", "ObjectName", null, "JobId",0, 0);
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Channel may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/PutObjectRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Channel",
+                () -> new PutObjectRequest("BucketName", "ObjectName", null, "JobId",0, 0));
     }
 
     @Test
     public void putObjectNullStreamUuidConstructorTest() {
-        try {
-            new PutObjectRequest("BucketName", "ObjectName", UUID.randomUUID(), 0, 0, null);
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Stream may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/PutObjectRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Stream",
+                () -> new PutObjectRequest("BucketName", "ObjectName", UUID.randomUUID(), 0, 0, null));
     }
 
     @Test
     public void putObjectNullStreamStringConstructorTest() {
-        try {
-            new PutObjectRequest("BucketName", "ObjectName", "JobId", 0, 0, null);
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Stream may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/PutObjectRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Stream",
+                () -> new PutObjectRequest("BucketName", "ObjectName", "JobId", 0, 0, null));
     }
 
     @Test
     public void putMultiPartUploadNullChannelUuidConstructorTest() {
-        try {
-            new PutMultiPartUploadPartRequest("BucketName", "ObjectName", null, 0, 0, UUID.randomUUID());
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Channel may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Channel",
+                () -> new PutMultiPartUploadPartRequest("BucketName", "ObjectName", null, 0, 0, UUID.randomUUID()));
     }
 
     @Test
     public void putMultiPartUploadNullChannelStringConstructorTest() {
-        try {
-            new PutMultiPartUploadPartRequest("BucketName", "ObjectName", null, 0, 0, "UploadId");
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Channel may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'channel' of com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Channel",
+                () -> new PutMultiPartUploadPartRequest("BucketName", "ObjectName", null, 0, 0, "UploadId"));
     }
 
     @Test
     public void putMultiPartUploadNullStreamUuidConstructorTest() {
-        try {
-            new PutMultiPartUploadPartRequest("BucketName", "ObjectName", 0, 0, null, UUID.randomUUID());
-            fail();
-        } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Stream may not be null."));
-        } catch (final IllegalArgumentException e) {
-            // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.<init> must not be null"));
-        }
+        testNonnullStreamChannelExceptions("Stream",
+                () -> new PutMultiPartUploadPartRequest("BucketName", "ObjectName", 0, 0, null, UUID.randomUUID()));
     }
 
     @Test
     public void putMultiPartUploadNullStreamStringConstructorTest() {
+        testNonnullStreamChannelExceptions("Stream",
+                () -> new PutMultiPartUploadPartRequest("BucketName", "ObjectName", 0, 0, null, "UploadId"));
+    }
+
+    private void testNonnullStreamChannelExceptions(final String paramName, final Runnable runnable) {
         try {
-            new PutMultiPartUploadPartRequest("BucketName", "ObjectName", 0, 0, null, "UploadId");
+            runnable.run();
             fail();
         } catch (final NullPointerException e) {
-            assertThat(e.getMessage(), is("Stream may not be null."));
+            assertThat(e.getMessage(), is(paramName + " may not be null."));
         } catch (final IllegalArgumentException e) {
             // IntelliJ IDEA throws an IllegalArgumentException if parameters are annotated as non-null are passed null values
-            assertThat(e.getMessage(), is("Argument for @Nonnull parameter 'stream' of com/spectralogic/ds3client/commands/PutMultiPartUploadPartRequest.<init> must not be null"));
+            assertThat(e.getMessage(), startsWith("Argument for @Nonnull parameter '" + paramName.toLowerCase() + "'"));
         }
     }
 }


### PR DESCRIPTION
All constructors with stream or channel inputs now have a negative test to verify preconditions are working as expected. This consists of all constructors for:
- GetObjectRequest
- PutObjectRequest
- PutMultiPartUploadPartRequest

Note: each tests is catching two exceptions. The null pointer exception is thrown by the precondition in the constructor (expected), and the illegal argument exception is thrown in IntelliJ IDEA due to the Nonnull annotation.