### PR TITLE
Fix for https://jira.spectralogic.com/browse/JSDK-264

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/transferstrategy/ExecutorServiceFactory.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/transferstrategy/ExecutorServiceFactory.java
@@ -1,0 +1,22 @@
+/*
+ * ****************************************************************************
+ *    Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *    Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *    this file except in compliance with the License. A copy of the License is located at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file.
+ *    This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *    specific language governing permissions and limitations under the License.
+ *  ****************************************************************************
+ */
+
+package com.spectralogic.ds3client.helpers.strategy.transferstrategy;
+
+import java.util.concurrent.ExecutorService;
+
+public interface ExecutorServiceFactory {
+    ExecutorService makeExecutorService();
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/transferstrategy/MultiThreadedTransferStrategy.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/transferstrategy/MultiThreadedTransferStrategy.java
@@ -35,10 +35,10 @@ public class MultiThreadedTransferStrategy extends AbstractTransferStrategy {
                                          final FailureEvent.FailureActivity failureActivity)
     {
         super(blobStrategy,
-              jobState,
-              MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(numConcurrentTransferThreads)),
-              eventDispatcher,
-              masterObjectList,
-              failureActivity);
+                jobState,
+                () -> MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(numConcurrentTransferThreads)),
+                eventDispatcher,
+                masterObjectList,
+                failureActivity);
     }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/transferstrategy/SingleThreadedTransferStrategy.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/transferstrategy/SingleThreadedTransferStrategy.java
@@ -34,10 +34,10 @@ public class SingleThreadedTransferStrategy extends AbstractTransferStrategy {
                                           final FailureEvent.FailureActivity failureActivity)
     {
         super(blobStrategy,
-              jobState,
-              MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor()),
-              eventDispatcher,
-              masterObjectList,
-              failureActivity);
+                jobState,
+                () -> MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor()),
+                eventDispatcher,
+                masterObjectList,
+                failureActivity);
     }
 }


### PR DESCRIPTION
We were using a single executor to handle every transfer in a job.  In large jobs,
this would cause the executor to hold onto the memory for all the transfers
in the job.