### PR TITLE
Fix for https://jira.spectralogic.com/browse/BPBROWSER-408

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/ExceptionClassifier.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/ExceptionClassifier.java
@@ -22,7 +22,7 @@ public final class ExceptionClassifier {
     private ExceptionClassifier() { }
 
     public static boolean isRecoverableException(final Throwable t) {
-        if (t instanceof UnrecoverableIOException || t instanceof FileSystemException || t instanceof SecurityException) {
+        if (t instanceof UnrecoverableIOException || t instanceof FileSystemException || t instanceof SecurityException || t instanceof NoSuchMethodException) {
             return false;
         }
 


### PR DESCRIPTION
Seems that building on a machine that has both java 8 & 9 JDKs using the java 8 javac causes java 9
jars to get pulled in.