### PR TITLE
JSDK-109: Improve SSL GCM performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
   - oraclejdk8
 script: ./gradlew -S clean jar ds3-sdk:test

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
 
 allprojects {
     group = 'com.spectralogic.ds3'
-    version = '3.2.8-COMPAT-4'
+    version = '3.2.8-COMPAT-5'
 }
 
 subprojects {
@@ -23,7 +23,7 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'findbugs'
 
-    sourceCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_8
     repositories {
         mavenCentral()
         mavenLocal()
@@ -41,7 +41,7 @@ subprojects {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '3.1'
+    gradleVersion = '4.6'
 }
 
 project(':ds3-sdk-integration') {

--- a/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/Smoke_Test.java
+++ b/ds3-sdk-integration/src/test/java/com/spectralogic/ds3client/integration/Smoke_Test.java
@@ -51,10 +51,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.file.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -378,6 +375,14 @@ public class Smoke_Test {
         }
     }
 
+    private Map< String, Set< UUID >> objectsToMap(final Iterable<Contents> objs) {
+        Map<String, Set<UUID>> objMap = new HashMap<>();
+        for (Contents next : objs) {
+            objMap.put(next.getKey(), null);
+        }
+        return objMap;
+    }
+
     @Test
     public void multiObjectDeleteNotQuiet() throws IOException, URISyntaxException {
         final String bucketName = "multi_object_delete";
@@ -388,7 +393,7 @@ public class Smoke_Test {
 
             final Iterable<Contents> objs = HELPERS.listObjects(bucketName);
             final DeleteObjectsResponse response = client
-                    .deleteObjects(new DeleteObjectsRequest(bucketName, objs).withQuiet(false));
+                    .deleteObjects(new DeleteObjectsRequest(bucketName, objectsToMap(objs)).withQuiet(false));
             assertThat(response, is(notNullValue()));
             assertThat(response.getDeleteResult(), is(notNullValue()));
             assertThat(response.getDeleteResult().getDeletedObjects().size(), is(4));
@@ -410,7 +415,7 @@ public class Smoke_Test {
 
             final Iterable<Contents> objs = HELPERS.listObjects(bucketName);
             final DeleteObjectsResponse response = client
-                    .deleteObjects(new DeleteObjectsRequest(bucketName, objs).withQuiet(true));
+                    .deleteObjects(new DeleteObjectsRequest(bucketName, objectsToMap(objs)).withQuiet(true));
             assertThat(response, is(notNullValue()));
             assertThat(response.getDeleteResult(), is(notNullValue()));
             assertThat(response.getDeleteResult().getDeletedObjects().size(), is(0));
@@ -429,7 +434,11 @@ public class Smoke_Test {
         try {
             HELPERS.ensureBucketExists(bucketName, envDataPolicyId);
 
-            final List<String> objList = Lists.newArrayList("badObj1.txt", "badObj2.txt", "badObj3.txt");
+            final Map<String, Set<UUID>> objList = new HashMap<>();
+            objList.put("badObj1.txt", null);
+            objList.put("badObj2.txt", null);
+            objList.put("badObj3.txt", null);
+
             final DeleteObjectsResponse response = client
                     .deleteObjects(new DeleteObjectsRequest(bucketName, objList));
             assertThat(response, is(notNullValue()));

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip


### PR DESCRIPTION
- Updating build to use Java 8 for improvements in SSL library
- Updating to Gradle 4.6
- Also fixed some non-compiling tests
- Reeving version to COMPAT-5