### PR TITLE
Test all Java LTS versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,16 +5,33 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  build:
+  check-deps:
+    name: Compile main and test classes with fresh dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '8'
+          check-latest: true
+      - run: ./gradlew clean classes testClasses --refresh-dependencies
+  test:
+    name: Test with multiple Temurin JDK versions
+    strategy:
+      matrix:
+        test-jdk-version: [ 8, 11, 17 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        name: Setup Temurin JDK ${{ matrix.test-jdk-version }}
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.test-jdk-version }}
           cache: 'gradle'
           check-latest: true
-      - name: Run PR Tests
-        run: ./gradlew -S clean jar :ds3-sdk:test :ds3-utils:test :ds3-metadata:test
+      - name: Compile and assemble main project with Temurin JDK ${{ matrix.test-jdk-version }}
+        run: ./gradlew clean assemble
+      - name: Test with Temurin JDK ${{ matrix.test-jdk-version }}
+        run: ./gradlew -S :ds3-sdk:test :ds3-utils:test :ds3-metadata:test

--- a/buildSrc/src/main/kotlin/ds3-java-sdk-internal-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/ds3-java-sdk-internal-convention.gradle.kts
@@ -17,8 +17,15 @@ plugins {
     `java`
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+tasks.compileJava {
+    options.encoding = "UTF-8"
+    // since java 8 is the minimum version supported, make sure we always
+    // produce java 8 bytecode
+    if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+        options.release.set(8)
+    } else {
+        // java 8 does not have a release option, so use source and target compatibility
+        setSourceCompatibility(JavaVersion.VERSION_1_8.toString())
+        setTargetCompatibility(JavaVersion.VERSION_1_8.toString())
     }
 }

--- a/buildSrc/src/main/kotlin/ds3-java-sdk-library-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/ds3-java-sdk-library-convention.gradle.kts
@@ -14,14 +14,9 @@
  */
 
 plugins {
+    id("ds3-java-sdk-internal-convention")
     `java-library`
 }
 
 group = "com.spectralogic.ds3"
 version = "5.4.1"
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
-    }
-}


### PR DESCRIPTION
Update GitHub actions to use all LTS versions of Java for testing (currently 8,
11, and 17), and make sure gradle is configured to produce Java 8 bytecode no
matter what JDK is used.