### PR TITLE
Enable local publishing

### DIFF
--- a/buildSrc/src/main/kotlin/ds3-java-sdk-library-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/ds3-java-sdk-library-convention.gradle.kts
@@ -16,11 +16,20 @@
 plugins {
     id("ds3-java-sdk-internal-convention")
     `java-library`
+    `maven-publish`
     id("org.owasp.dependencycheck")
 }
 
 group = "com.spectralogic.ds3"
 version = "5.4.1"
+
+publishing {
+    publications {
+        create<MavenPublication>("ProjectPublication") {
+            from(components["java"])
+        }
+    }
+}
 
 dependencyCheck {
     // fail the build if any vulnerable dependencies are identified (CVSS score > 0)


### PR DESCRIPTION
In addition to allow us to publish to our own local maven repository, this will allow jitpack to create artifacts for us to use.