### PR TITLE
Run integrationTest task in docker

### DIFF
--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -20,5 +20,5 @@ cd ds3_java_sdk
 git rev-parse HEAD
 
 ./gradlew jar
-./gradlew test
+./gradlew test integrationTest
 


### PR DESCRIPTION
In addition to the unit tests, make sure to run the integration tests when running the test suite in docker.