### PR TITLE
Control group and version info in one location

### DIFF
--- a/buildSrc/src/main/kotlin/ds3-java-sdk-library-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/ds3-java-sdk-library-convention.gradle.kts
@@ -21,9 +21,6 @@ plugins {
     id("org.owasp.dependencycheck")
 }
 
-group = "com.spectralogic.ds3"
-version = "5.4.1"
-
 publishing {
     publications {
         create<MavenPublication>("ProjectPublication") {


### PR DESCRIPTION
Make buildSrc/src/main/kotlin/ds3-java-sdk-library-convention.gradle.kts the only place where group and version are defined.