### PR TITLE
Redo 5.6.2 release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
           check-latest: true
-      - run: ./gradlew clean classes testClasses integrationTestClasses --refresh-dependencies
+      - run: ./gradlew clean classes testClasses integrationTestClasses shadowJar --refresh-dependencies
   test:
     name: Test with multiple Temurin JDK versions
     strategy:

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -16,7 +16,7 @@
 #
 # project version
 #
-ds3SdkVersion = "5.6.2"
+ds3SdkVersion = "5.6.3-SNAPSHOT"
 #
 # dependency versions
 #
@@ -27,7 +27,7 @@ findbugsVersion = "3.0.1"
 guavaVersion = "32.1.2-jre"
 hamcrestVersion = "2.2"
 httpclientVersion = "4.5.13"
-jacksonVersion = "2.14.3"
+jacksonVersion = "2.14.3" # stuck on 2.14.x until we move away from Java 8 as a minimum supported version
 jnaVersion = "5.12.1"
 junitJupiterVersion = "5.9.0"
 junitVersion = "4.13.2"

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -16,7 +16,7 @@
 #
 # project version
 #
-ds3SdkVersion = "5.6.3-SNAPSHOT"
+ds3SdkVersion = "5.6.2"
 #
 # dependency versions
 #
@@ -27,7 +27,7 @@ findbugsVersion = "3.0.1"
 guavaVersion = "32.1.2-jre"
 hamcrestVersion = "2.2"
 httpclientVersion = "4.5.13"
-jacksonVersion = "2.15.2"
+jacksonVersion = "2.14.3"
 jnaVersion = "5.12.1"
 junitJupiterVersion = "5.9.0"
 junitVersion = "4.13.2"


### PR DESCRIPTION
Jackson 2.15.x brings in a dependency that is not compatible with Java 8, and the shadowJar task fails. We will be stuck on Jackson 2.14.x until we move on from Java 8 support.