### PR TITLE
Allow for the use of a NIST NVD API key

### DIFF
--- a/buildSrc/src/main/kotlin/ds3-java-sdk-library-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/ds3-java-sdk-library-convention.gradle.kts
@@ -58,4 +58,5 @@ dependencyCheck {
     // fail the build if any vulnerable dependencies are identified (CVSS score > 0)
     failBuildOnCVSS = 0f;
     suppressionFile = "project_files/owasp/dependency-check-suppression.xml"
+    nvd.apiKey = System.getenv("NVD_API_KEY")
 }

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -70,7 +70,7 @@ slf4jSimple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j
 # plugins used in buildSrc/
 #
 kotlinJvmPlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlinVersion" }
-owaspDepCheckPlugin = { group = "org.owasp", name = "dependency-check-gradle", version = "8.4.0" }
+owaspDepCheckPlugin = { group = "org.owasp", name = "dependency-check-gradle", version = "10.0.3" }
 versionsPlugin = { group = "com.github.ben-manes", name = "gradle-versions-plugin", version = "0.47.0" }
 
 [plugins]


### PR DESCRIPTION
Look for a NIST NVD API key in the environment variable NVD_API_KEY and, if found, use it when running the OWASP dependency check tasks.