### PR TITLE
Issue-625: allow injecting a custom HttpClient into the Ds3Client without relying solely on the internal builder logic.

### DIFF
--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientBuilder.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientBuilder.java
@@ -40,6 +40,7 @@ public class Ds3ClientBuilder implements Builder<Ds3Client> {
     static final private String ACCESS_KEY = "DS3_ACCESS_KEY";
     static final private String SECRET_KEY = "DS3_SECRET_KEY";
 
+    private NetworkClient networkClient;
     final private String endpoint;
     final private Credentials credentials;
 
@@ -199,10 +200,21 @@ public class Ds3ClientBuilder implements Builder<Ds3Client> {
     }
 
     /**
+     * Set a custom NetworkClient implementation.  If this is set, all other connection parameters will be ignored.
+     */
+    public Ds3ClientBuilder withNetworkClient(final NetworkClient networkClient) {
+        this.networkClient = networkClient;
+        return this;
+    }
+
+    /**
      * Returns a new Ds3Client instance.
      */
     @Override
     public Ds3Client build() {
+        if (this.networkClient != null) {
+            return new Ds3ClientImpl(this.networkClient);
+        }
         LOG.info("Making connection details for endpoint [{}] using this authorization id [{}]",
                 this.endpoint, this.credentials.getClientId());
         final ConnectionDetailsImpl.Builder connBuilder = ConnectionDetailsImpl

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/NetworkClientImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/networking/NetworkClientImpl.java
@@ -93,7 +93,7 @@ public class NetworkClientImpl implements NetworkClient {
         this(connectionDetails, createDefaultClient(connectionDetails));
     }
 
-    private NetworkClientImpl(final ConnectionDetails connectionDetails, final CloseableHttpClient client) {
+    public NetworkClientImpl(final ConnectionDetails connectionDetails, final CloseableHttpClient client) {
         if (connectionDetails == null) throw new AssertionError("ConnectionDetails cannot be null");
         if (client == null) throw new AssertionError("CloseableHttpClient cannot be null");
         try {

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/Issue625Injection_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/Issue625Injection_Test.java
@@ -1,0 +1,39 @@
+package com.spectralogic.ds3client;
+
+import com.spectralogic.ds3client.models.common.Credentials;
+import com.spectralogic.ds3client.networking.ConnectionDetails;
+import com.spectralogic.ds3client.networking.NetworkClient;
+import com.spectralogic.ds3client.networking.NetworkClientImpl;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class Issue625Injection_Test {
+
+    @Test(timeout = 10000)
+    public void testHttpClientInjection() {
+        final ConnectionDetails connectionDetails = ConnectionDetailsImpl.builder("http://localhost:8080", new Credentials("id", "key")).build();
+        final CloseableHttpClient customHttpClient = HttpClients.createDefault();
+        
+        // This constructor was previously private
+        final NetworkClient netClient = new NetworkClientImpl(connectionDetails, customHttpClient);
+        
+        final Ds3Client ds3Client = new Ds3ClientImpl(netClient);
+        
+        assertThat(((Ds3ClientImpl)ds3Client).getNetClient(), is(netClient));
+    }
+
+    @Test(timeout = 10000)
+    public void testBuilderNetworkClientInjection() {
+        final NetworkClient netClient = mock(NetworkClient.class);
+        
+        final Ds3Client ds3Client = Ds3ClientBuilder.create("http://localhost:8080", new Credentials("id", "key"))
+                .withNetworkClient(netClient)
+                .build();
+        
+        assertThat(((Ds3ClientImpl)ds3Client).getNetClient(), is(netClient));
+    }
+}


### PR DESCRIPTION
- Changed the access modifier of the NetworkClientImpl constructor that accepts a CloseableHttpClient from private to public, enabling external injection of custom-configured HTTP clients.
- Added a withNetworkClient(NetworkClient) method to Ds3ClientBuilder to allow users to provide a pre-configured NetworkClient (potentially wrapping a custom HttpClient) through the builder interface.
- Updated the Ds3ClientBuilder.build() method to prioritize the provided networkClient if it has been set.