### PR TITLE
Maven Central publication tasks (gradle)

### DIFF
--- a/buildSrc/src/main/kotlin/ds3-java-sdk-library-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/ds3-java-sdk-library-convention.gradle.kts
@@ -28,7 +28,6 @@ kotlin {
     jvmToolchain {
         (this as JavaToolchainSpec).apply {
             languageVersion.set(JavaLanguageVersion.of("8"))
-            vendor.set(JvmVendorSpec.ADOPTIUM)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/ds3-java-sdk-publishing-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/ds3-java-sdk-publishing-common-convention.gradle.kts
@@ -20,6 +20,8 @@ plugins {
     signing
 }
 
+var mavenCentralPrepDir = rootProject.layout.buildDirectory.dir("deployment/central/")
+
 publishing {
     repositories {
         maven {
@@ -38,17 +40,7 @@ publishing {
         }
         maven {
             name = "OSSRH"
-            val releasesOssrhRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            val snapshotsOssrhRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-            url = uri(if (extra["isReleaseVersion"] as Boolean) releasesOssrhRepoUrl else snapshotsOssrhRepoUrl)
-            credentials {
-                username = extra.has("ossrhUsername").let {
-                    if (it) extra.get("ossrhUsername") as String else null
-                }
-                password = extra.has("ossrhPassword").let {
-                    if (it) extra.get("ossrhPassword") as String else null
-                }
-            }
+            url = uri(mavenCentralPrepDir)
         }
     }
 }
@@ -61,12 +53,38 @@ tasks.register("publishToInternalRepository") {
     })
 }
 
-tasks.register("publishToSonatypeOSSRH") {
+var prepareMavenCentralPayload = tasks.register("prepareMavenCentralPayload") {
     group = "publishing"
-    description = "Publishes all Maven publications to Sonatype's OSSRH repository."
+    description = "Generate files for payload to submit to maven central."
     dependsOn(tasks.withType<PublishToMavenRepository>().matching {
         it.repository == publishing.repositories["OSSRH"]
     })
+    doLast {
+        // remove maven metadata, as it is only used in the local repository and
+        // not published to maven central
+        delete(fileTree(mavenCentralPrepDir) {
+            include("**/maven-metadata.xml*")
+        })
+    }
+}
+
+tasks.register<Tar>("generateMavenCentralPayload") {
+    // see https://central.sonatype.org/publish/publish-portal-upload/
+    group = "publishing"
+    description = "Create .tar.gz payload for submission to maven central."
+    archiveBaseName.set("ds3-java-sdk-maven-central")
+    archiveVersion.set("${version}")
+    archiveExtension.set("tar.gz")
+    compression = Compression.GZIP
+    from(mavenCentralPrepDir) {
+        include("**/*")
+    }
+    destinationDirectory.set(mavenCentralPrepDir.get().asFile.parentFile)
+    dependsOn(prepareMavenCentralPayload)
+}
+
+tasks.clean {
+    delete(mavenCentralPrepDir.get().asFile.parentFile)
 }
 
 val augmentPom = tasks.register("augmentPom") {


### PR DESCRIPTION
The workflow for publishing to maven central has changed. Unfortunately, Gradle no longer has the native capability to publish directly (this is being worked on by the Gradle team). However, there is an option to publish artifacts via manual upload. In order to do so, we need to generate an archive file containing the artifacts we wish to publish. This change modifies the build to leverage the 'local' publishing capabilities of Gradle to generate the file structure required by maven central prior to generating the archive file. To prepare the archive file, run:

./gradlew clean generateMavenCentralPayload

This will create the file build/deployment/ds3-java-sdk-maven-central-<version>.tar.gz, which can then be uploaded to maven central for deployment. See https://central.sonatype.org/publish/publish-portal-upload/ for more details.

This PR contains a second, more minor change, that allows for any JDK 8 to build the project ( not just Temurin). This is important for MacOS users, as Temurin does not produce a JDK 8 for MacOS arm64 architecture (but Amazon Corretto does).