### PR TITLE
Deprecate AllocateJobChunk and update helpers to use GetJobChunksReadyForClientProcessing

### DIFF
--- a/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/AdvancedBucketManagement_Test.java
+++ b/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/AdvancedBucketManagement_Test.java
@@ -91,12 +91,13 @@ public class AdvancedBucketManagement_Test {
 
         try {
             //Create a test storage domain
-            final PutStorageDomainSpectraS3Response storageDomainResponse = createStorageDomain(
+            final StorageDomain storageDomain = createStorageDomain(
                     storageDomainName,
-                    client);
+                    client,
+                    true);
 
-            assertThat(storageDomainResponse.getStorageDomainResult(), is(notNullValue()));
-            assertThat(storageDomainResponse.getStorageDomainResult().getName(), is(storageDomainName));
+            assertThat(storageDomain, is(notNullValue()));
+            assertThat(storageDomain.getName(), is(storageDomainName));
         } finally {
             //Delete the test storage domain
             deleteStorageDomain(storageDomainName, client);
@@ -109,13 +110,14 @@ public class AdvancedBucketManagement_Test {
 
         try {
             //Create the pool partition
-            final PutPoolPartitionSpectraS3Response createPoolResponse = createPoolPartition(
+            final PoolPartition poolPartition = createPoolPartition(
                     poolPartitionName,
                     PoolType.ONLINE,
-                    client);
+                    client,
+                    true);
 
-            assertThat(createPoolResponse.getPoolPartitionResult(), is(notNullValue()));
-            assertThat(createPoolResponse.getPoolPartitionResult().getName(), is(poolPartitionName));
+            assertThat(poolPartition, is(notNullValue()));
+            assertThat(poolPartition.getName(), is(poolPartitionName));
 
             //Get the pool partition to verify that was created on the BP
             final GetPoolPartitionSpectraS3Response getPoolResponse = client
@@ -136,34 +138,38 @@ public class AdvancedBucketManagement_Test {
         UUID storageDomainMemberId = null;
         try {
             //Create storage domain
-            final PutStorageDomainSpectraS3Response createStorageDomain = createStorageDomain(
+            final StorageDomain storageDomain = createStorageDomain(
                     storageDomainName,
-                    client);
+                    client,
+                    true);
 
             //Create pool partition
-            final PutPoolPartitionSpectraS3Response createPoolPartition = createPoolPartition(
+            final PoolPartition poolPartition = createPoolPartition(
                     poolPartitionName,
                     PoolType.ONLINE,
-                    client);
+                    client,
+                    true);
 
             //Create storage domain member linking pool partition to storage domain
-            final PutPoolStorageDomainMemberSpectraS3Response createMemberResponse = createPoolStorageDomainMember(
-                    createStorageDomain.getStorageDomainResult().getId(),
-                    createPoolPartition.getPoolPartitionResult().getId(),
-                    client);
-            storageDomainMemberId = createMemberResponse.getStorageDomainMemberResult().getId();
-            assertThat(createMemberResponse.getStorageDomainMemberResult(), is(notNullValue()));
+            final StorageDomainMember storageDomainMember = createPoolStorageDomainMember(
+                    storageDomain.getId(),
+                    poolPartition.getId(),
+                    client,
+                    true);
+
+            assertThat(storageDomainMember, is(notNullValue()));
+            storageDomainMemberId = storageDomainMember.getId();
 
             //Verify that the storage domain member exists
             final GetStorageDomainMembersSpectraS3Response getMembers = client.getStorageDomainMembersSpectraS3(
                     new GetStorageDomainMembersSpectraS3Request()
-                            .withPoolPartitionId(createPoolPartition.getPoolPartitionResult().getId().toString())
-                            .withStorageDomainId(createStorageDomain.getStorageDomainResult().getId().toString()));
+                            .withPoolPartitionId(poolPartition.getId().toString())
+                            .withStorageDomainId(storageDomain.getId().toString()));
 
             final List<StorageDomainMember> members = getMembers.getStorageDomainMemberListResult().getStorageDomainMembers();
             assertThat(members.size(), is(1));
-            assertThat(members.get(0).getPoolPartitionId(), is(createPoolPartition.getPoolPartitionResult().getId()));
-            assertThat(members.get(0).getStorageDomainId(), is(createStorageDomain.getStorageDomainResult().getId()));
+            assertThat(members.get(0).getPoolPartitionId(), is(poolPartition.getId()));
+            assertThat(members.get(0).getStorageDomainId(), is(storageDomain.getId()));
         } finally {
             deleteStorageDomainMember(storageDomainMemberId, client);
             deletePoolPartition(poolPartitionName, client);
@@ -201,29 +207,33 @@ public class AdvancedBucketManagement_Test {
                     client);
 
             //Create storage domain
-            final PutStorageDomainSpectraS3Response storageDomainResponse = createStorageDomain(
+            final StorageDomain storageDomain = createStorageDomain(
                     storageDomainName,
-                    client);
+                    client,
+                    true);
 
             //Create pool partition
-            final PutPoolPartitionSpectraS3Response poolPartitionResponse = createPoolPartition(
+            final PoolPartition poolPartition = createPoolPartition(
                     poolPartitionName,
                     PoolType.ONLINE,
-                    client);
+                    client,
+                    true);
 
             //Create storage domain member linking pool partition to storage domain
-            final PutPoolStorageDomainMemberSpectraS3Response memberResponse = createPoolStorageDomainMember(
-                    storageDomainResponse.getStorageDomainResult().getId(),
-                    poolPartitionResponse.getPoolPartitionResult().getId(),
-                    client);
-            storageDomainMemberId = memberResponse.getStorageDomainMemberResult().getId();
+            final StorageDomainMember storageDomainMember = createPoolStorageDomainMember(
+                    storageDomain.getId(),
+                    poolPartition.getId(),
+                    client,
+                    true);
+            storageDomainMemberId = storageDomainMember.getId();
 
             //create data persistence rule
-            final PutDataPersistenceRuleSpectraS3Response dataPersistenceResponse = createDataPersistenceRule(
+            final DataPersistenceRule dataPersistenceRule = createDataPersistenceRule(
                     dataPolicyResponse.getDataPolicyResult().getId(),
-                    storageDomainResponse.getStorageDomainResult().getId(),
-                    client);
-            dataPersistenceRuleId = dataPersistenceResponse.getDataPersistenceRuleResult().getDataPolicyId();
+                    storageDomain.getId(),
+                    client,
+                    true);
+            dataPersistenceRuleId = dataPersistenceRule.getDataPolicyId();
 
             //Create bucket with data policy
             final PutBucketSpectraS3Response bucketResponse = client
@@ -261,29 +271,33 @@ public class AdvancedBucketManagement_Test {
                     client);
 
             //Create storage domain
-            final PutStorageDomainSpectraS3Response storageDomainResponse = createStorageDomain(
+            final StorageDomain storageDomain = createStorageDomain(
                     storageDomainName,
-                    client);
+                    client,
+                    true);
 
             //Create pool partition
-            final PutPoolPartitionSpectraS3Response poolPartitionResponse = createPoolPartition(
+            final PoolPartition poolPartition = createPoolPartition(
                     poolPartitionName,
                     PoolType.ONLINE,
-                    client);
+                    client,
+                    true);
 
             //Create storage domain member linking pool partition to storage domain
-            final PutPoolStorageDomainMemberSpectraS3Response memberResponse = createPoolStorageDomainMember(
-                    storageDomainResponse.getStorageDomainResult().getId(),
-                    poolPartitionResponse.getPoolPartitionResult().getId(),
-                    client);
-            storageDomainMemberId = memberResponse.getStorageDomainMemberResult().getId();
+            final StorageDomainMember storageDomainMember = createPoolStorageDomainMember(
+                    storageDomain.getId(),
+                    poolPartition.getId(),
+                    client,
+                    true);
+            storageDomainMemberId = storageDomainMember.getId();
 
             //create data persistence rule
-            final PutDataPersistenceRuleSpectraS3Response dataPersistenceResponse = createDataPersistenceRule(
+            final DataPersistenceRule dataPersistenceRule = createDataPersistenceRule(
                     dataPolicyResponse.getDataPolicyResult().getId(),
-                    storageDomainResponse.getStorageDomainResult().getId(),
-                    client);
-            dataPersistenceRuleId = dataPersistenceResponse.getDataPersistenceRuleResult().getDataPolicyId();
+                    storageDomain.getId(),
+                    client,
+                    true);
+            dataPersistenceRuleId = dataPersistenceRule.getId();
 
             //Create bucket with data policy
             client.putBucketSpectraS3(new PutBucketSpectraS3Request(bucketName)
@@ -333,29 +347,33 @@ public class AdvancedBucketManagement_Test {
                     client);
 
             //Create storage domain
-            final PutStorageDomainSpectraS3Response storageDomainResponse = createStorageDomain(
+            final StorageDomain storageDomain = createStorageDomain(
                     storageDomainName,
-                    client);
+                    client,
+                    true);
 
             //Create pool partition
-            final PutPoolPartitionSpectraS3Response poolPartitionResponse = createPoolPartition(
+            final PoolPartition poolPartition = createPoolPartition(
                     poolPartitionName,
                     PoolType.ONLINE,
-                    client);
+                    client,
+                    true);
 
             //Create storage domain member linking pool partition to storage domain
-            final PutPoolStorageDomainMemberSpectraS3Response memberResponse = createPoolStorageDomainMember(
-                    storageDomainResponse.getStorageDomainResult().getId(),
-                    poolPartitionResponse.getPoolPartitionResult().getId(),
-                    client);
-            storageDomainMemberId = memberResponse.getStorageDomainMemberResult().getId();
+            final StorageDomainMember storageDomainMember = createPoolStorageDomainMember(
+                    storageDomain.getId(),
+                    poolPartition.getId(),
+                    client,
+                    true);
+            storageDomainMemberId = storageDomainMember.getId();
 
             //create data persistence rule
-            final PutDataPersistenceRuleSpectraS3Response dataPersistenceResponse = createDataPersistenceRule(
+            final DataPersistenceRule dataPersistenceRule = createDataPersistenceRule(
                     dataPolicyResponse.getDataPolicyResult().getId(),
-                    storageDomainResponse.getStorageDomainResult().getId(),
-                    client);
-            dataPersistenceRuleId = dataPersistenceResponse.getDataPersistenceRuleResult().getDataPolicyId();
+                    storageDomain.getId(),
+                    client,
+                    true);
+            dataPersistenceRuleId = dataPersistenceRule.getDataPolicyId();
 
             //Create bucket with data policy
             client.putBucketSpectraS3(new PutBucketSpectraS3Request(bucketName)

--- a/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/PutJobManagement_Test.java
+++ b/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/PutJobManagement_Test.java
@@ -42,7 +42,6 @@ import com.spectralogic.ds3client.metadata.MetadataAccessImpl;
 import com.spectralogic.ds3client.models.*;
 import com.spectralogic.ds3client.models.Objects;
 import com.spectralogic.ds3client.models.bulk.Ds3Object;
-import com.spectralogic.ds3client.networking.FailedRequestException;
 import com.spectralogic.ds3client.utils.ByteArraySeekableByteChannel;
 import com.spectralogic.ds3client.utils.Platform;
 import com.spectralogic.ds3client.utils.ResourceUtils;
@@ -50,7 +49,6 @@ import com.spectralogic.ds3client.utils.collections.LazyIterable;
 import com.spectralogic.ds3client.utils.hashing.ChecksumUtils;
 import com.spectralogic.ds3client.utils.hashing.Hasher;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.junit.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +62,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.nio.channels.Channels;
 import java.nio.channels.SeekableByteChannel;
@@ -91,7 +88,6 @@ public class PutJobManagement_Test {
     private static final Ds3Client client = Util.fromEnv();
     private static final Ds3ClientHelpers HELPERS = Ds3ClientHelpers.wrap(client);
     private static final String BUCKET_NAME = "Put_Job_Management_Test";
-
     private static final String TEST_ENV_NAME = "PutJobManagement_Test";
     private static TempStorageIds envStorageIds;
     private static UUID envDataPolicyId;
@@ -116,18 +112,6 @@ public class PutJobManagement_Test {
     public static void teardown() throws IOException {
         TempStorageUtil.teardown(TEST_ENV_NAME, envStorageIds, client);
         client.close();
-    }
-
-    private static long getCacheBytesAvailable() throws IOException {
-        long cacheAvailableBytes = 0;
-        final List<CacheFilesystemInformation> cacheFilesystemInformationList = client.getCacheStateSpectraS3(
-                new GetCacheStateSpectraS3Request()).getCacheInformationResult().getFilesystems();
-        for (final CacheFilesystemInformation filesystemInformation : cacheFilesystemInformationList) {
-            if (filesystemInformation.getAvailableCapacityInBytes() > cacheAvailableBytes) {
-                cacheAvailableBytes = filesystemInformation.getAvailableCapacityInBytes();
-            }
-        }
-        return cacheAvailableBytes;
     }
 
     @SuppressWarnings("deprecation")
@@ -1068,7 +1052,7 @@ public class PutJobManagement_Test {
                 }, computeChecksumWithUserSuppliedFunction);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testWriteJobWithRetriesThrowsDs3NoMoreRetriesException() throws Exception {
         final int maxNumObjectTransferAttempts = 1;
         final boolean computeChecksumWithUserSuppliedFunction = false;
@@ -1087,7 +1071,7 @@ public class PutJobManagement_Test {
                 }, computeChecksumWithUserSuppliedFunction);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testFiringOnFailureEventWithFailedChunkAllocation()
             throws IOException, URISyntaxException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         final String tempPathPrefix = null;
@@ -1149,7 +1133,7 @@ public class PutJobManagement_Test {
         return ds3ClientHelpers.startWriteJob(BUCKET_NAME, objects);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testFiringWaitingForChunksEventWithFailedChunkAllocation()
             throws IOException, URISyntaxException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         final String tempPathPrefix = null;
@@ -1159,7 +1143,7 @@ public class PutJobManagement_Test {
             final AtomicInteger numFailureEventsFired = new AtomicInteger(0);
             final AtomicInteger numWaitingForChunksEventsFired = new AtomicInteger(0);
 
-            final int maxNumObjectTransferAttempts = 3;
+            final int maxNumObjectTransferAttempts = 1;
             final Ds3ClientHelpers.Job writeJob = createWriteJobWithObjectsReadyToTransfer(maxNumObjectTransferAttempts,
                     ClientFailureType.ChunkAllocation);
 
@@ -1180,13 +1164,9 @@ public class PutJobManagement_Test {
                 }
             });
 
-            try {
-                writeJob.transfer(new FileObjectPutter(tempDirectory));
-            } catch (final Ds3NoMoreRetriesException e) {
-                assertEquals(1, numFailureEventsFired.get());
-            }
+            writeJob.transfer(new FileObjectPutter(tempDirectory));
 
-            assertEquals(maxNumObjectTransferAttempts, numWaitingForChunksEventsFired.get());
+            assertThat(numWaitingForChunksEventsFired.get(), is(greaterThanOrEqualTo(1)));
         } finally {
             FileUtils.deleteDirectory(tempDirectory.toFile());
             cancelAllJobsForBucket(client, BUCKET_NAME);
@@ -1398,7 +1378,7 @@ public class PutJobManagement_Test {
         {
             this.monitorable = monitorable;
 
-            wrappedBlobStrategy = new PutSequentialBlobStrategy(client, masterObjectList, eventDispatcher, retryBehavior, chunkAttemptRetryDelayBehavior);
+            wrappedBlobStrategy = new PutBlobStrategy(client, masterObjectList, eventDispatcher, retryBehavior, chunkAttemptRetryDelayBehavior, false);
         }
 
         @Override
@@ -2122,7 +2102,7 @@ public class PutJobManagement_Test {
         assertTrue(getJobRan.get());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testStreamedPutJobWithBlobbedFile() throws Exception {
         final int chunkSize = MIN_UPLOAD_SIZE_IN_BYTES;
         final long biggerThanAChunkSize = chunkSize * 2L + 1024;

--- a/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/PutJobManagement_Test.java
+++ b/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/PutJobManagement_Test.java
@@ -1164,9 +1164,11 @@ public class PutJobManagement_Test {
                 }
             });
 
-            writeJob.transfer(new FileObjectPutter(tempDirectory));
-
-            assertThat(numWaitingForChunksEventsFired.get(), is(greaterThanOrEqualTo(1)));
+            try {
+                writeJob.transfer(new FileObjectPutter(tempDirectory));
+            } catch (final Ds3NoMoreRetriesException e) {
+                assertThat(numWaitingForChunksEventsFired.get(), is(greaterThanOrEqualTo(1)));
+            }
         } finally {
             FileUtils.deleteDirectory(tempDirectory.toFile());
             cancelAllJobsForBucket(client, BUCKET_NAME);
@@ -1378,7 +1380,7 @@ public class PutJobManagement_Test {
         {
             this.monitorable = monitorable;
 
-            wrappedBlobStrategy = new PutBlobStrategy(client, masterObjectList, eventDispatcher, retryBehavior, chunkAttemptRetryDelayBehavior, false);
+            wrappedBlobStrategy = new PutSequentialBlobStrategy(client, masterObjectList, eventDispatcher, retryBehavior, chunkAttemptRetryDelayBehavior);
         }
 
         @Override

--- a/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/Smoke_Test.java
+++ b/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/Smoke_Test.java
@@ -630,29 +630,33 @@ public class Smoke_Test {
                     client);
 
             //Create storage domain
-            final PutStorageDomainSpectraS3Response storageDomainResponse = createStorageDomain(
+            final StorageDomain storageDomain = createStorageDomain(
                     storageDomainName,
-                    client);
+                    client,
+                    true);
 
             //Create pool partition
-            final PutPoolPartitionSpectraS3Response poolPartitionResponse = createPoolPartition(
+            final PoolPartition poolPartition = createPoolPartition(
                     poolPartitionName,
                     PoolType.ONLINE,
-                    client);
+                    client,
+                    true);
 
             //Create storage domain member linking pool partition to storage domain
-            final PutPoolStorageDomainMemberSpectraS3Response memberResponse = createPoolStorageDomainMember(
-                    storageDomainResponse.getStorageDomainResult().getId(),
-                    poolPartitionResponse.getPoolPartitionResult().getId(),
-                    client);
-            storageDomainMemberId = memberResponse.getStorageDomainMemberResult().getId();
+            final StorageDomainMember storageDomainMember = createPoolStorageDomainMember(
+                    storageDomain.getId(),
+                    poolPartition.getId(),
+                    client,
+                    true);
+            storageDomainMemberId = storageDomainMember.getId();
 
             //create data persistence rule
-            final PutDataPersistenceRuleSpectraS3Response dataPersistenceResponse = createDataPersistenceRule(
+            final DataPersistenceRule dataPersistenceRule = createDataPersistenceRule(
                     dataPolicyResponse.getDataPolicyResult().getId(),
-                    storageDomainResponse.getStorageDomainResult().getId(),
-                    client);
-            dataPersistenceRuleId = dataPersistenceResponse.getDataPersistenceRuleResult().getDataPolicyId();
+                    storageDomain.getId(),
+                    client,
+                    true);
+            dataPersistenceRuleId = dataPersistenceRule.getDataPolicyId();
 
             //Create bucket with data policy
             client.putBucketSpectraS3(new PutBucketSpectraS3Request(bucketName)

--- a/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/test/helpers/ABMTestHelper.java
+++ b/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/test/helpers/ABMTestHelper.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 import static org.apache.http.util.TextUtils.isEmpty;
@@ -162,14 +163,19 @@ public final class ABMTestHelper {
      * partition with the same name does not currently exist. If a partition
      * already exists with the specified name, an error is thrown.
      */
-    public static PutPoolPartitionSpectraS3Response createPoolPartition(
+    public static PoolPartition createPoolPartition(
             final String poolPartitionName,
             final PoolType poolType,
-            final Ds3Client client) throws IOException {
+            final Ds3Client client,
+            boolean failIfAlreadyExists) throws IOException {
         //Check if pool partition already exists
         try {
-            client.getPoolPartitionSpectraS3(new GetPoolPartitionSpectraS3Request(poolPartitionName));
-            fail("Pool partition already exists, terminating to prevent conflict: " + poolPartitionName);
+            final GetPoolPartitionSpectraS3Response getPoolPartition = client.getPoolPartitionSpectraS3(
+                    new GetPoolPartitionSpectraS3Request(poolPartitionName));
+            if (failIfAlreadyExists) {
+                fail("Pool partition already exists, terminating to prevent conflict: " + poolPartitionName);
+            }
+            return getPoolPartition.getPoolPartitionResult();
         } catch (final IOException e) {
             //Pass: expected pool partition to not exist
         }
@@ -177,7 +183,7 @@ public final class ABMTestHelper {
         //Create the pool partition
         return client.putPoolPartitionSpectraS3(new PutPoolPartitionSpectraS3Request(
                 poolPartitionName,
-                poolType));
+                poolType)).getPoolPartitionResult();
     }
 
     /**
@@ -212,19 +218,24 @@ public final class ABMTestHelper {
      * Creates a storage domain if one does not already exist with the specified name. If a
      * storage domain already exists with the specified name, an error is thrown.
      */
-    public static PutStorageDomainSpectraS3Response createStorageDomain(
+    public static StorageDomain createStorageDomain(
             final String storageDomainName,
-            final Ds3Client client) throws IOException {
+            final Ds3Client client,
+            boolean failIfAlreadyExists) throws IOException {
         //Check if storage domain already exists
         try {
-            client.getStorageDomainSpectraS3(new GetStorageDomainSpectraS3Request(storageDomainName));
-            fail("Storage domain already exists, terminating to prevent conflict: " + storageDomainName);
+            final GetStorageDomainSpectraS3Response getStorageDomain = client.getStorageDomainSpectraS3(
+                    new GetStorageDomainSpectraS3Request(storageDomainName));
+            if (failIfAlreadyExists) {
+                fail("Storage domain already exists, terminating to prevent conflict: " + storageDomainName);
+            }
+            return getStorageDomain.getStorageDomainResult();
         } catch (final IOException e) {
             //Pass: expected storage domain to not exist
         }
 
         //Create the storage domain
-        return client.putStorageDomainSpectraS3(new PutStorageDomainSpectraS3Request(storageDomainName));
+        return client.putStorageDomainSpectraS3(new PutStorageDomainSpectraS3Request(storageDomainName)).getStorageDomainResult();
     }
 
     /**
@@ -260,17 +271,23 @@ public final class ABMTestHelper {
      * storage domain and pool partition. If a storage domain member already exists,an
      * error is thrown.
      */
-    public static PutPoolStorageDomainMemberSpectraS3Response createPoolStorageDomainMember(
+    public static StorageDomainMember createPoolStorageDomainMember(
             final UUID storageDomainId,
             final UUID poolPartitionId,
-            final Ds3Client client) throws IOException {
+            final Ds3Client client,
+            boolean failIfAlreadyExists) throws IOException {
         //Check if storage domain member already exists between specified storage domain and pool partition
         try {
             final GetStorageDomainMembersSpectraS3Response getMembers = client.getStorageDomainMembersSpectraS3(
                     new GetStorageDomainMembersSpectraS3Request()
                             .withPoolPartitionId(poolPartitionId.toString())
                             .withStorageDomainId(storageDomainId.toString()));
-            assertThat(getMembers.getStorageDomainMemberListResult().getStorageDomainMembers().size(), is(0));
+            if (failIfAlreadyExists) {
+                assertThat(getMembers.getStorageDomainMemberListResult().getStorageDomainMembers().size(), is(0));
+            }
+            if (!getMembers.getStorageDomainMemberListResult().getStorageDomainMembers().isEmpty()) {
+                return getMembers.getStorageDomainMemberListResult().getStorageDomainMembers().get(0);
+            }
         } catch (final IOException e) {
             //Pass: expected storage domain member to not exist
         }
@@ -278,7 +295,7 @@ public final class ABMTestHelper {
         //Create the storage domain
         return client.putPoolStorageDomainMemberSpectraS3(new PutPoolStorageDomainMemberSpectraS3Request(
                 poolPartitionId.toString(),
-                storageDomainId.toString()));
+                storageDomainId.toString())).getStorageDomainMemberResult();
     }
 
     /**
@@ -315,23 +332,29 @@ public final class ABMTestHelper {
      * Creates a data persistence rule to link the specified data policy and storage domain,
      * if said rule does not already exist.
      */
-    public static PutDataPersistenceRuleSpectraS3Response createDataPersistenceRule(
+    public static DataPersistenceRule createDataPersistenceRule(
             final UUID dataPolicyId,
             final UUID storageDomainId,
-            final Ds3Client client) throws IOException {
+            final Ds3Client client,
+            boolean failIfAlreadyExists) throws IOException {
         //Check if data persistence rule already exists
         final GetDataPersistenceRulesSpectraS3Response response = client.getDataPersistenceRulesSpectraS3(
                 new GetDataPersistenceRulesSpectraS3Request()
                         .withDataPolicyId(dataPolicyId.toString())
                         .withStorageDomainId(storageDomainId.toString()));
-        assertThat(response.getDataPersistenceRuleListResult().getDataPersistenceRules().size(), is(0));
+        if (failIfAlreadyExists) {
+            assertThat(response.getDataPersistenceRuleListResult().getDataPersistenceRules().size(), is(0));
+        }
+        if (!response.getDataPersistenceRuleListResult().getDataPersistenceRules().isEmpty()) {
+            return response.getDataPersistenceRuleListResult().getDataPersistenceRules().get(0);
+        }
 
         //Create the data persistence rule
         return client.putDataPersistenceRuleSpectraS3(new PutDataPersistenceRuleSpectraS3Request(
                 dataPolicyId.toString(),
                 DataIsolationLevel.STANDARD,
                 storageDomainId.toString(),
-                DataPersistenceRuleType.PERMANENT));
+                DataPersistenceRuleType.PERMANENT)).getDataPersistenceRuleResult();
     }
 
     /**

--- a/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/test/helpers/Ds3ClientShimWithFailedChunkAllocation.java
+++ b/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/test/helpers/Ds3ClientShimWithFailedChunkAllocation.java
@@ -17,10 +17,7 @@ package com.spectralogic.ds3client.integration.test.helpers;
 
 import com.spectralogic.ds3client.Ds3ClientImpl;
 import com.spectralogic.ds3client.MockedWebResponse;
-import com.spectralogic.ds3client.commands.parsers.AllocateJobChunkSpectraS3ResponseParser;
 import com.spectralogic.ds3client.commands.parsers.GetJobChunksReadyForClientProcessingSpectraS3ResponseParser;
-import com.spectralogic.ds3client.commands.spectrads3.AllocateJobChunkSpectraS3Request;
-import com.spectralogic.ds3client.commands.spectrads3.AllocateJobChunkSpectraS3Response;
 import com.spectralogic.ds3client.commands.spectrads3.GetJobChunksReadyForClientProcessingSpectraS3Request;
 import com.spectralogic.ds3client.commands.spectrads3.GetJobChunksReadyForClientProcessingSpectraS3Response;
 
@@ -36,16 +33,6 @@ public class Ds3ClientShimWithFailedChunkAllocation extends Ds3ClientShim {
         super(ds3ClientImpl);
     }
 
-    @Override
-    public AllocateJobChunkSpectraS3Response allocateJobChunkSpectraS3(final AllocateJobChunkSpectraS3Request request)
-            throws IOException
-    {
-        final AllocateJobChunkSpectraS3Response allocateJobChunkSpectraS3Response =
-                new AllocateJobChunkSpectraS3ResponseParser()
-                        .parseXmlResponse(new MockedWebResponse("A response", 307, makeFailingResponseHeaders()));
-
-        return allocateJobChunkSpectraS3Response;
-    }
 
     private static Map<String, String> makeFailingResponseHeaders() {
         final Map<String, String> headers = new HashMap<>();

--- a/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/test/helpers/Ds3ClientShimWithFailedChunkAllocation.java
+++ b/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/test/helpers/Ds3ClientShimWithFailedChunkAllocation.java
@@ -50,7 +50,7 @@ public class Ds3ClientShimWithFailedChunkAllocation extends Ds3ClientShim {
     private static Map<String, String> makeFailingResponseHeaders() {
         final Map<String, String> headers = new HashMap<>();
         headers.put("content-NONE", "text/xml");
-        headers.put("Retry-After", "1");
+        headers.put("Retry-After", "0");
 
         return headers;
     }
@@ -61,7 +61,7 @@ public class Ds3ClientShimWithFailedChunkAllocation extends Ds3ClientShim {
     {
         final GetJobChunksReadyForClientProcessingSpectraS3Response getJobChunksReadyForClientProcessingSpectraS3Response =
                 new GetJobChunksReadyForClientProcessingSpectraS3ResponseParser()
-                        .parseXmlResponse(new MockedWebResponse("A response", 307, makeFailingResponseHeaders()));
+                        .parseXmlResponse(new MockedWebResponse("<MasterObjectList><Objects/></MasterObjectList>", 200, makeFailingResponseHeaders()));
 
         return getJobChunksReadyForClientProcessingSpectraS3Response;
     }

--- a/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/test/helpers/TempStorageUtil.java
+++ b/ds3-sdk-integration/src/integrationTest/java/com/spectralogic/ds3client/integration/test/helpers/TempStorageUtil.java
@@ -17,9 +17,7 @@ package com.spectralogic.ds3client.integration.test.helpers;
 
 import com.spectralogic.ds3client.Ds3Client;
 import com.spectralogic.ds3client.commands.spectrads3.*;
-import com.spectralogic.ds3client.models.ChecksumType;
-import com.spectralogic.ds3client.models.PoolType;
-import com.spectralogic.ds3client.models.VersioningLevel;
+import com.spectralogic.ds3client.models.*;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -51,29 +49,33 @@ public final class TempStorageUtil {
             final UUID dataPolicyId,
             final Ds3Client client) throws IOException {
         //Create storage domain
-        final PutStorageDomainSpectraS3Response storageDomainResponse = createStorageDomain(
+        final StorageDomain storageDomain = createStorageDomain(
                 testSetName + STORAGE_DOMAIN_NAME,
-                client);
+                client,
+                false);
 
         //Create pool partition
-        final PutPoolPartitionSpectraS3Response poolPartitionResponse = createPoolPartition(
+        final PoolPartition poolPartition = createPoolPartition(
                 testSetName + POOL_PARTITION_NAME,
                 PoolType.ONLINE,
-                client);
+                client,
+                false);
 
         //Create storage domain member linking pool partition to storage domain
-        final PutPoolStorageDomainMemberSpectraS3Response memberResponse = createPoolStorageDomainMember(
-                storageDomainResponse.getStorageDomainResult().getId(),
-                poolPartitionResponse.getPoolPartitionResult().getId(),
-                client);
-        final UUID storageDomainMemberId = memberResponse.getStorageDomainMemberResult().getId();
+        final StorageDomainMember storageDomainMember = createPoolStorageDomainMember(
+                storageDomain.getId(),
+                poolPartition.getId(),
+                client,
+                false);
+        final UUID storageDomainMemberId = storageDomainMember.getId();
 
         //create data persistence rule
-        final PutDataPersistenceRuleSpectraS3Response dataPersistenceResponse = createDataPersistenceRule(
+        final DataPersistenceRule dataPersistenceRule = createDataPersistenceRule(
                 dataPolicyId,
-                storageDomainResponse.getStorageDomainResult().getId(),
-                client);
-        final UUID dataPersistenceRuleId = dataPersistenceResponse.getDataPersistenceRuleResult().getDataPolicyId();
+                storageDomain.getId(),
+                client,
+                false);
+        final UUID dataPersistenceRuleId = dataPersistenceRule.getDataPolicyId();
 
         return new TempStorageIds(storageDomainMemberId, dataPersistenceRuleId);
     }
@@ -101,6 +103,14 @@ public final class TempStorageUtil {
             final boolean withEndToEndCrcRequired,
             final ChecksumType.Type checksumType,
             final Ds3Client client) throws IOException {
+        try {
+            return client.getDataPolicySpectraS3(
+                    new GetDataPolicySpectraS3Request(testSetName + DATA_POLICY_NAME)).getDataPolicyResult().getId();
+        } catch (final IOException e) {
+            // Pass: Expected data policy to not exist
+        }
+
+
         final PutDataPolicySpectraS3Response dataPolicyResponse = client.putDataPolicySpectraS3(
                 new PutDataPolicySpectraS3Request(testSetName + DATA_POLICY_NAME)
                         .withEndToEndCrcRequired(withEndToEndCrcRequired)
@@ -119,6 +129,13 @@ public final class TempStorageUtil {
             final ChecksumType.Type checksumType,
             final VersioningLevel versioningLevel,
             final Ds3Client client) throws IOException {
+        try {
+            return client.getDataPolicySpectraS3(
+                    new GetDataPolicySpectraS3Request(testSetName + DATA_POLICY_NAME)).getDataPolicyResult().getId();
+        } catch (final IOException e) {
+            // Pass: Expected data policy to not exist
+        }
+
         final PutDataPolicySpectraS3Response dataPolicyResponse = client.putDataPolicySpectraS3(
                 new PutDataPolicySpectraS3Request(testSetName + DATA_POLICY_NAME)
                         .withEndToEndCrcRequired(withEndToEndCrcRequired)

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3Client.java
@@ -732,6 +732,8 @@ public interface Ds3Client extends Closeable {
     @Action("MODIFY")
     @Resource("JOB_CHUNK")
     
+    /** @deprecated Use {@link #getJobChunksReadyForClientProcessingSpectraS3(GetJobChunksReadyForClientProcessingSpectraS3Request)} instead */
+    @Deprecated
     AllocateJobChunkSpectraS3Response allocateJobChunkSpectraS3(final AllocateJobChunkSpectraS3Request request)
             throws IOException;
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientImpl.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/Ds3ClientImpl.java
@@ -466,6 +466,8 @@ public class Ds3ClientImpl implements Ds3Client {
         return new VerifyUserIsMemberOfGroupSpectraS3ResponseParser().response(this.netClient.getResponse(request));
     }
     @Override
+    /** @deprecated Use {@link #getJobChunksReadyForClientProcessingSpectraS3(GetJobChunksReadyForClientProcessingSpectraS3Request)} instead */
+    @Deprecated
     public AllocateJobChunkSpectraS3Response allocateJobChunkSpectraS3(final AllocateJobChunkSpectraS3Request request) throws IOException {
         return new AllocateJobChunkSpectraS3ResponseParser().response(this.netClient.getResponse(request));
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/parsers/AllocateJobChunkSpectraS3ResponseParser.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/parsers/AllocateJobChunkSpectraS3ResponseParser.java
@@ -26,6 +26,8 @@ import com.spectralogic.ds3client.serializer.XmlOutput;
 import java.io.IOException;
 import java.io.InputStream;
 
+/** @deprecated Use {@link GetJobChunksReadyForClientProcessingSpectraS3ResponseParser} instead */
+@Deprecated
 public class AllocateJobChunkSpectraS3ResponseParser extends AbstractResponseParser<AllocateJobChunkSpectraS3Response> {
     private final int[] expectedStatusCodes = new int[]{200, 307, 503};
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/parsers/GetJobChunksReadyForClientProcessingSpectraS3ResponseParser.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/parsers/GetJobChunksReadyForClientProcessingSpectraS3ResponseParser.java
@@ -42,7 +42,7 @@ public class GetJobChunksReadyForClientProcessingSpectraS3ResponseParser extends
                     if (isNullOrEmpty(result.getObjects())) {
                         return new GetJobChunksReadyForClientProcessingSpectraS3Response(result, parseRetryAfter(response), GetJobChunksReadyForClientProcessingSpectraS3Response.Status.RETRYLATER, this.getChecksum(), this.getChecksumType());
                     }
-                    return new GetJobChunksReadyForClientProcessingSpectraS3Response(result, 0, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE, this.getChecksum(), this.getChecksumType());
+                    return new GetJobChunksReadyForClientProcessingSpectraS3Response(result, parseRetryAfter(response), GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE, this.getChecksum(), this.getChecksumType());
                 }
 
             default:

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/AllocateJobChunkSpectraS3Request.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/AllocateJobChunkSpectraS3Request.java
@@ -20,6 +20,8 @@ import com.spectralogic.ds3client.networking.HttpVerb;
 import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
 import java.util.UUID;
 
+/** @deprecated Use {@link GetJobChunksReadyForClientProcessingSpectraS3Request} instead */
+@Deprecated
 public class AllocateJobChunkSpectraS3Request extends AbstractRequest {
 
     // Variables

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/AllocateJobChunkSpectraS3Response.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/AllocateJobChunkSpectraS3Response.java
@@ -20,6 +20,8 @@ import com.spectralogic.ds3client.models.Objects;
 import com.spectralogic.ds3client.models.ChecksumType;
 import com.spectralogic.ds3client.commands.interfaces.AbstractResponse;
 
+/** @deprecated Use {@link GetJobChunksReadyForClientProcessingSpectraS3Response} instead */
+@Deprecated
 public class AllocateJobChunkSpectraS3Response extends AbstractResponse {
 
     public enum Status { ALLOCATED, RETRYLATER }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobState.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/JobState.java
@@ -50,6 +50,10 @@ public class JobState {
         return blobs.contains(new BlobIdentityDecorator(blob));
     }
 
+    public boolean isEmpty() {
+        return blobs.isEmpty();
+    }
+
     public int numBlobsInJob() {
         return numBlobsInJob;
     }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy.java
@@ -8,6 +8,7 @@ import com.spectralogic.ds3client.commands.spectrads3.GetJobChunksReadyForClient
 import com.spectralogic.ds3client.commands.spectrads3.GetJobChunksReadyForClientProcessingSpectraS3Response;
 import com.spectralogic.ds3client.exceptions.Ds3NoMoreRetriesException;
 import com.spectralogic.ds3client.helpers.JobPart;
+import com.spectralogic.ds3client.helpers.JobState;
 import com.spectralogic.ds3client.helpers.strategy.transferstrategy.EventDispatcher;
 import com.spectralogic.ds3client.models.BulkObject;
 import com.spectralogic.ds3client.models.MasterObjectList;
@@ -23,14 +24,18 @@ import java.util.UUID;
 public class PutBlobStrategy extends AbstractBlobStrategy {
     private final boolean streamingStrategyEnabled;
 
+    private final JobState jobState;
+
     public PutBlobStrategy(final Ds3Client client,
                            final MasterObjectList masterObjectList,
                            final EventDispatcher eventDispatcher,
                            final ChunkAttemptRetryBehavior retryBehavior,
                            final ChunkAttemptRetryDelayBehavior chunkAttemptRetryDelayBehavior,
+                           final JobState jobState,
                            final boolean streamingStrategy)
     {
         super(client, masterObjectList, eventDispatcher, retryBehavior, chunkAttemptRetryDelayBehavior);
+        this.jobState = jobState;
         this.streamingStrategyEnabled = streamingStrategy;
     }
     @Override
@@ -41,59 +46,52 @@ public class PutBlobStrategy extends AbstractBlobStrategy {
     @Override
     public Iterable<JobPart> getWork() throws IOException, InterruptedException {
         do {
-            final GetJobChunksReadyForClientProcessingSpectraS3Response response = getJobChunksReadyForClientProcessingSpectraS3WithRetry();
+            final GetJobChunksReadyForClientProcessingSpectraS3Response response = client().getJobChunksReadyForClientProcessingSpectraS3(
+                    new GetJobChunksReadyForClientProcessingSpectraS3Request(this.masterObjectList().getJobId()));
 
-            final Set<UUID> objectIds = new HashSet<>();
-            final Iterable<JobPart> work = FluentIterable.from(response.getMasterObjectListResult().getObjects())
-                    .transformAndConcat(new Function<Objects, Iterable<? extends JobPart>>() {
-                        @Nullable
-                        @Override
-                        public Iterable<? extends JobPart> apply(@Nullable final Objects chunk) {
-                            return FluentIterable.from(chunk.getObjects())
-                                    .filter(input -> {
-                                        if (input.getInCache()) {
-                                            return false;
-                                        }
-                                        if (streamingStrategyEnabled) {
-                                            return objectIds.add(input.getId());
-                                        }
-                                        return true;
-                                    })
-                                    .transform(new Function<BulkObject, JobPart>() {
-                                        @Nullable
-                                        @Override
-                                        public JobPart apply(@Nullable final BulkObject blob) {
-                                            return new JobPart(client(), blob);
-                                        }
-                                    });
-                        }
-                    });
-            if (work.iterator().hasNext()) {
-                retryBehavior().reset();
-                return work;
-            }
-            try {
-                retryBehavior().invoke();
-            } catch (final Ds3NoMoreRetriesException e) {
-                return ImmutableList.of();
-            }
-            chunkAttemptRetryDelayBehavior().delay(1); //TODO change to response.retryAfterSeconds once all tests are passing with this hard coded value
-        } while (true);
-    }
-
-    private GetJobChunksReadyForClientProcessingSpectraS3Response getJobChunksReadyForClientProcessingSpectraS3WithRetry() throws IOException, InterruptedException {
-        while (true) {
-            final GetJobChunksReadyForClientProcessingSpectraS3Response response = client().getJobChunksReadyForClientProcessingSpectraS3(new GetJobChunksReadyForClientProcessingSpectraS3Request(this.masterObjectList().getJobId()));
-            if (response.getStatus() == GetJobChunksReadyForClientProcessingSpectraS3Response.Status.RETRYLATER) {
-                try {
-                    retryBehavior().invoke();
-                } catch (final Ds3NoMoreRetriesException e) {
-                    return response;
+            if (response.getStatus() == GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE) {
+                final Set<UUID> objectIds = new HashSet<>();
+                final ImmutableList<JobPart> work = FluentIterable.from(response.getMasterObjectListResult().getObjects())
+                        .transformAndConcat(new Function<Objects, Iterable<? extends JobPart>>() {
+                            @Nullable
+                            @Override
+                            public Iterable<? extends JobPart> apply(@Nullable final Objects chunk) {
+                                return FluentIterable.from(chunk.getObjects())
+                                        .filter(input -> {
+                                            if (input.getInCache()) {
+                                                jobState.blobTransferredOrFailed(input);
+                                                return false;
+                                            }
+                                            if (!jobState.contains(input)) {
+                                                return false;
+                                            }
+                                            if (streamingStrategyEnabled) {
+                                                return objectIds.add(input.getId());
+                                            }
+                                            return true;
+                                        })
+                                        .transform(new Function<BulkObject, JobPart>() {
+                                            @Nullable
+                                            @Override
+                                            public JobPart apply(@Nullable final BulkObject blob) {
+                                                return new JobPart(client(), blob);
+                                            }
+                                        });
+                            }
+                        }).toList();
+                if (!work.isEmpty()) {
+                    retryBehavior().reset();
+                    return work;
                 }
-                chunkAttemptRetryDelayBehavior().delay(response.getRetryAfterSeconds());
-            } else {
-                return response;
+
+                if (jobState.isEmpty()) {
+                    retryBehavior().reset();
+                    return Collections.emptyList();
+                }
             }
-        }
+
+            retryBehavior().invoke();
+            chunkAttemptRetryDelayBehavior().delay(response.getRetryAfterSeconds());
+        } while (true);
     }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy.java
@@ -91,7 +91,7 @@ public class PutBlobStrategy extends AbstractBlobStrategy {
             }
 
             retryBehavior().invoke();
-            chunkAttemptRetryDelayBehavior().delay(response.getRetryAfterSeconds());
+            chunkAttemptRetryDelayBehavior().delay(response.getRetryAfterSeconds() > 0 ? response.getRetryAfterSeconds() : 1);
         } while (true);
     }
 }

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy.java
@@ -1,0 +1,99 @@
+package com.spectralogic.ds3client.helpers.strategy.blobstrategy;
+
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3client.Ds3Client;
+import com.spectralogic.ds3client.commands.spectrads3.GetJobChunksReadyForClientProcessingSpectraS3Request;
+import com.spectralogic.ds3client.commands.spectrads3.GetJobChunksReadyForClientProcessingSpectraS3Response;
+import com.spectralogic.ds3client.exceptions.Ds3NoMoreRetriesException;
+import com.spectralogic.ds3client.helpers.JobPart;
+import com.spectralogic.ds3client.helpers.strategy.transferstrategy.EventDispatcher;
+import com.spectralogic.ds3client.models.BulkObject;
+import com.spectralogic.ds3client.models.MasterObjectList;
+import com.spectralogic.ds3client.models.Objects;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class PutBlobStrategy extends AbstractBlobStrategy {
+    private final boolean streamingStrategyEnabled;
+
+    public PutBlobStrategy(final Ds3Client client,
+                           final MasterObjectList masterObjectList,
+                           final EventDispatcher eventDispatcher,
+                           final ChunkAttemptRetryBehavior retryBehavior,
+                           final ChunkAttemptRetryDelayBehavior chunkAttemptRetryDelayBehavior,
+                           final boolean streamingStrategy)
+    {
+        super(client, masterObjectList, eventDispatcher, retryBehavior, chunkAttemptRetryDelayBehavior);
+        this.streamingStrategyEnabled = streamingStrategy;
+    }
+    @Override
+    public void blobCompleted(BulkObject bulkObject) {
+        // Intentionally not implemented
+    }
+
+    @Override
+    public Iterable<JobPart> getWork() throws IOException, InterruptedException {
+        do {
+            final GetJobChunksReadyForClientProcessingSpectraS3Response response = getJobChunksReadyForClientProcessingSpectraS3WithRetry();
+
+            final Set<UUID> objectIds = new HashSet<>();
+            final Iterable<JobPart> work = FluentIterable.from(response.getMasterObjectListResult().getObjects())
+                    .transformAndConcat(new Function<Objects, Iterable<? extends JobPart>>() {
+                        @Nullable
+                        @Override
+                        public Iterable<? extends JobPart> apply(@Nullable final Objects chunk) {
+                            return FluentIterable.from(chunk.getObjects())
+                                    .filter(input -> {
+                                        if (input.getInCache()) {
+                                            return false;
+                                        }
+                                        if (streamingStrategyEnabled) {
+                                            return objectIds.add(input.getId());
+                                        }
+                                        return true;
+                                    })
+                                    .transform(new Function<BulkObject, JobPart>() {
+                                        @Nullable
+                                        @Override
+                                        public JobPart apply(@Nullable final BulkObject blob) {
+                                            return new JobPart(client(), blob);
+                                        }
+                                    });
+                        }
+                    });
+            if (work.iterator().hasNext()) {
+                retryBehavior().reset();
+                return work;
+            }
+            try {
+                retryBehavior().invoke();
+            } catch (final Ds3NoMoreRetriesException e) {
+                return ImmutableList.of();
+            }
+            chunkAttemptRetryDelayBehavior().delay(1); //TODO change to response.retryAfterSeconds once all tests are passing with this hard coded value
+        } while (true);
+    }
+
+    private GetJobChunksReadyForClientProcessingSpectraS3Response getJobChunksReadyForClientProcessingSpectraS3WithRetry() throws IOException, InterruptedException {
+        while (true) {
+            final GetJobChunksReadyForClientProcessingSpectraS3Response response = client().getJobChunksReadyForClientProcessingSpectraS3(new GetJobChunksReadyForClientProcessingSpectraS3Request(this.masterObjectList().getJobId()));
+            if (response.getStatus() == GetJobChunksReadyForClientProcessingSpectraS3Response.Status.RETRYLATER) {
+                try {
+                    retryBehavior().invoke();
+                } catch (final Ds3NoMoreRetriesException e) {
+                    return response;
+                }
+                chunkAttemptRetryDelayBehavior().delay(response.getRetryAfterSeconds());
+            } else {
+                return response;
+            }
+        }
+    }
+}

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutSequentialBlobStrategy.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutSequentialBlobStrategy.java
@@ -36,7 +36,9 @@ import static com.spectralogic.ds3client.helpers.strategy.StrategyUtils.filterCh
 
 /**
  * A subclass of {@link BlobStrategy} used in put transfers.
+ * @deprecated Use {@link PutBlobStrategy} instead
  */
+@Deprecated
 public class PutSequentialBlobStrategy extends AbstractBlobStrategy {
     private final static Logger LOG = LoggerFactory.getLogger(PutSequentialBlobStrategy.class);
 

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/transferstrategy/TransferStrategyBuilder.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/transferstrategy/TransferStrategyBuilder.java
@@ -35,16 +35,7 @@ import com.spectralogic.ds3client.helpers.events.EventRunner;
 import com.spectralogic.ds3client.helpers.events.FailureEvent;
 import com.spectralogic.ds3client.helpers.events.SameThreadEventRunner;
 import com.spectralogic.ds3client.helpers.strategy.StrategyUtils;
-import com.spectralogic.ds3client.helpers.strategy.blobstrategy.BlackPearlChunkAttemptRetryDelayBehavior;
-import com.spectralogic.ds3client.helpers.strategy.blobstrategy.BlobStrategy;
-import com.spectralogic.ds3client.helpers.strategy.blobstrategy.BlobStrategyMaker;
-import com.spectralogic.ds3client.helpers.strategy.blobstrategy.ChunkAttemptRetryDelayBehavior;
-import com.spectralogic.ds3client.helpers.strategy.blobstrategy.ClientDefinedChunkAttemptRetryDelayBehavior;
-import com.spectralogic.ds3client.helpers.strategy.blobstrategy.ContinueForeverChunkAttemptsRetryBehavior;
-import com.spectralogic.ds3client.helpers.strategy.blobstrategy.GetSequentialBlobStrategy;
-import com.spectralogic.ds3client.helpers.strategy.blobstrategy.MaxChunkAttemptsRetryBehavior;
-import com.spectralogic.ds3client.helpers.strategy.blobstrategy.PutSequentialBlobStrategy;
-import com.spectralogic.ds3client.helpers.strategy.blobstrategy.ChunkAttemptRetryBehavior;
+import com.spectralogic.ds3client.helpers.strategy.blobstrategy.*;
 import com.spectralogic.ds3client.helpers.strategy.channelstrategy.ChannelStrategy;
 import com.spectralogic.ds3client.helpers.strategy.channelstrategy.NullChannelPreparable;
 import com.spectralogic.ds3client.helpers.strategy.channelstrategy.RandomAccessChannelStrategy;
@@ -142,7 +133,7 @@ public final class TransferStrategyBuilder {
 
     /**
      * Use an instance of {@link BlobStrategy} you wish to create or retrieve blobs from a Black Pearl.  There are
-     * 2 primary implementations: {@link PutSequentialBlobStrategy}; and {@link GetSequentialBlobStrategy}.  Blob
+     * 2 primary implementations: {@link PutBlobStrategy}; and {@link GetSequentialBlobStrategy}.  Blob
      * retrieval order is specified in the
      * {@link com.spectralogic.ds3client.commands.spectrads3.GetBulkJobSpectraS3Request#withChunkClientProcessingOrderGuarantee(com.spectralogic.ds3client.models.JobChunkClientProcessingOrderGuarantee)}
      * HTTP request.
@@ -474,11 +465,12 @@ public final class TransferStrategyBuilder {
         getOrMakeTransferRetryDecorator();
 
         return makeTransferStrategy(
-                (client, masterObjectList, eventDispatcher) -> new PutSequentialBlobStrategy(ds3Client,
+                (client, masterObjectList, eventDispatcher) -> new PutBlobStrategy(ds3Client,
                         masterObjectList,
                         eventDispatcher,
                         getOrMakeChunkAttemptRetryBehavior(),
-                        getOrMakeChunkAllocationRetryDelayBehavior()
+                        getOrMakeChunkAllocationRetryDelayBehavior(),
+                        true
                 ),
                 this::makePutTransferMethod);
     }
@@ -605,12 +597,12 @@ public final class TransferStrategyBuilder {
                                                          final MasterObjectList masterObjectList,
                                                          final EventDispatcher eventDispatcher)
                     {
-                        return new PutSequentialBlobStrategy(ds3Client,
+                        return new PutBlobStrategy(ds3Client,
                                 masterObjectList,
                                 eventDispatcher,
                                 getOrMakeChunkAttemptRetryBehavior(),
-                                getOrMakeChunkAllocationRetryDelayBehavior()
-                                );
+                                getOrMakeChunkAllocationRetryDelayBehavior(),
+                                false);
                     }
                 },
                 new TransferMethodMaker() {
@@ -769,11 +761,12 @@ public final class TransferStrategyBuilder {
                                                          final MasterObjectList masterObjectList,
                                                          final EventDispatcher eventDispatcher)
                     {
-                        return new PutSequentialBlobStrategy(ds3Client,
+                        return new PutBlobStrategy(ds3Client,
                                 masterObjectList,
                                 eventDispatcher,
                                 getOrMakeChunkAttemptRetryBehavior(),
-                                getOrMakeChunkAllocationRetryDelayBehavior()
+                                getOrMakeChunkAllocationRetryDelayBehavior(),
+                                false
                         );
                     }
                 },

--- a/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/transferstrategy/TransferStrategyBuilder.java
+++ b/ds3-sdk/src/main/java/com/spectralogic/ds3client/helpers/strategy/transferstrategy/TransferStrategyBuilder.java
@@ -470,6 +470,7 @@ public final class TransferStrategyBuilder {
                         eventDispatcher,
                         getOrMakeChunkAttemptRetryBehavior(),
                         getOrMakeChunkAllocationRetryDelayBehavior(),
+                        getOrMakeJobStateForPutJob(),
                         true
                 ),
                 this::makePutTransferMethod);
@@ -602,6 +603,7 @@ public final class TransferStrategyBuilder {
                                 eventDispatcher,
                                 getOrMakeChunkAttemptRetryBehavior(),
                                 getOrMakeChunkAllocationRetryDelayBehavior(),
+                                getOrMakeJobStateForPutJob(),
                                 false);
                     }
                 },
@@ -766,6 +768,7 @@ public final class TransferStrategyBuilder {
                                 eventDispatcher,
                                 getOrMakeChunkAttemptRetryBehavior(),
                                 getOrMakeChunkAllocationRetryDelayBehavior(),
+                                getOrMakeJobStateForPutJob(),
                                 false
                         );
                     }

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/Ds3Client_Test.java
@@ -684,9 +684,11 @@ public class Ds3Client_Test {
 
         final Map<String, String> queryParams = new HashMap<>();
         queryParams.put("job", MASTER_OBJECT_LIST_JOB_ID.toString());
+        final Map<String, String> headers = new HashMap<>();
+        headers.put("retry-after", "10");
         final GetJobChunksReadyForClientProcessingSpectraS3Response response = MockNetwork
             .expecting(HttpVerb.GET, "/_rest_/job_chunk", queryParams, null)
-            .returning(200, MASTER_OBJECT_LIST_XML)
+            .returning(200, MASTER_OBJECT_LIST_XML, headers)
             .asClient()
             .getJobChunksReadyForClientProcessingSpectraS3(new GetJobChunksReadyForClientProcessingSpectraS3Request(MASTER_OBJECT_LIST_JOB_ID.toString()));
         

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpers_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/Ds3ClientHelpers_Test.java
@@ -144,15 +144,21 @@ public class Ds3ClientHelpers_Test {
 
         final PutBulkJobSpectraS3Response bulkPutResponse = buildBulkPutResponse();
         Mockito.when(ds3Client.putBulkJobSpectraS3(any(PutBulkJobSpectraS3Request.class))).thenReturn(bulkPutResponse);
-        
-        final AllocateJobChunkSpectraS3Response allocateResponse1 = buildAllocateResponse1();
-        final AllocateJobChunkSpectraS3Response allocateResponse2 = buildAllocateResponse2();
-        final AllocateJobChunkSpectraS3Response allocateResponse3 = buildAllocateResponse3();
-        Mockito.when(ds3Client.allocateJobChunkSpectraS3(hasChunkId(CHUNK_ID_1)))
-            .thenReturn(allocateResponse1)
-            .thenReturn(allocateResponse2);
-        Mockito.when(ds3Client.allocateJobChunkSpectraS3(hasChunkId(CHUNK_ID_2)))
-            .thenReturn(allocateResponse3);
+
+        final MasterObjectList chunk1ReadyMol = new MasterObjectList();
+        chunk1ReadyMol.setObjects(Collections.singletonList(chunk1(false)));
+
+        final MasterObjectList chunk2ReadyMol = new MasterObjectList();
+        chunk2ReadyMol.setObjects(ImmutableList.of(chunk1(true), chunk2(false)));
+
+        final GetJobChunksReadyForClientProcessingSpectraS3Response response1 = retryGetAvailableAfter(1);
+        final GetJobChunksReadyForClientProcessingSpectraS3Response response2 = availableJobChunks(chunk1ReadyMol);
+        final GetJobChunksReadyForClientProcessingSpectraS3Response response3 = availableJobChunks(chunk2ReadyMol);
+
+        Mockito.when(ds3Client.getJobChunksReadyForClientProcessingSpectraS3(any()))
+            .thenReturn(response1)
+            .thenReturn(response2)
+            .thenReturn(response3);
 
         final PutObjectResponse response = mock(PutObjectResponse.class);
         Mockito.when(ds3Client.putObject(putRequestHas(MYBUCKET, "foo", jobId, 0, "foo co"))).thenReturn(response);
@@ -209,15 +215,9 @@ public class Ds3ClientHelpers_Test {
         final PutBulkJobSpectraS3Response buildBulkPutResponse = buildBulkPutResponse();
         Mockito.when(ds3Client.putBulkJobSpectraS3(any(PutBulkJobSpectraS3Request.class))).thenReturn(buildBulkPutResponse);
 
-        final AllocateJobChunkSpectraS3Response allocateResponse2 = buildAllocateResponse2();
-        final AllocateJobChunkSpectraS3Response allocateResponse3 = buildAllocateResponse3();
-
-        Mockito.when(ds3Client.allocateJobChunkSpectraS3(hasChunkId(CHUNK_ID_1))).thenReturn(allocateResponse2);
-
-        Mockito.when(ds3Client.allocateJobChunkSpectraS3(hasChunkId(CHUNK_ID_1)))
-                .thenReturn(allocateResponse2);
-        Mockito.when(ds3Client.allocateJobChunkSpectraS3(hasChunkId(CHUNK_ID_2)))
-                .thenReturn(allocateResponse3);
+        final GetJobChunksReadyForClientProcessingSpectraS3Response availableChunks = availableJobChunks(buildBulkPutResponse.getMasterObjectList());
+        Mockito.when(ds3Client.getJobChunksReadyForClientProcessingSpectraS3(any()))
+                .thenReturn(availableChunks);
 
         final PutObjectResponse putResponse = mock(PutObjectResponse.class);
         Mockito.when(ds3Client.putObject(putRequestHas(MYBUCKET, "foo", jobId, 0, "foo co"))).thenThrow(new StubException());
@@ -500,18 +500,6 @@ public class Ds3ClientHelpers_Test {
         ));
     }
 
-    private static AllocateJobChunkSpectraS3Response buildAllocateResponse1() {
-        return retryAllocateLater(1);
-    }
-    
-    private static AllocateJobChunkSpectraS3Response buildAllocateResponse2() {
-        return allocated(chunk1(false));
-    }
-    
-    private static AllocateJobChunkSpectraS3Response buildAllocateResponse3() {
-        return allocated(chunk2(false));
-    }
-
     private static MasterObjectList buildJobResponse(
             final JobRequestType requestType,
             final JobChunkClientProcessingOrderGuarantee chunkOrdering,
@@ -615,9 +603,9 @@ public class Ds3ClientHelpers_Test {
                 .putBulkJobSpectraS3(any(PutBulkJobSpectraS3Request.class)))
                 .thenReturn(bulkPutResponse);
 
-        final AllocateJobChunkSpectraS3Response allocateResponse1 = buildAllocateResponse1();
-        Mockito.when(ds3Client.allocateJobChunkSpectraS3(hasChunkId(CHUNK_ID_1)))
-                .thenReturn(allocateResponse1);
+        final GetJobChunksReadyForClientProcessingSpectraS3Response response1 = retryGetAvailableAfter(1);
+        Mockito.when(ds3Client.getJobChunksReadyForClientProcessingSpectraS3(any()))
+                .thenReturn(response1);
 
         final PutObjectResponse response = mock(PutObjectResponse.class);
         Mockito.when(ds3Client.putObject(putRequestHas(MYBUCKET, "foo", jobId, 0, "foo co"))).thenReturn(response);

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/Metadata_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/Metadata_Test.java
@@ -18,6 +18,7 @@ package com.spectralogic.ds3client.helpers;
 import com.spectralogic.ds3client.Ds3Client;
 import com.spectralogic.ds3client.commands.spectrads3.AllocateJobChunkSpectraS3Request;
 import com.spectralogic.ds3client.commands.spectrads3.AllocateJobChunkSpectraS3Response;
+import com.spectralogic.ds3client.commands.spectrads3.GetJobChunksReadyForClientProcessingSpectraS3Response;
 import com.spectralogic.ds3client.helpers.strategy.transferstrategy.TransferStrategy;
 import com.spectralogic.ds3client.helpers.strategy.transferstrategy.TransferStrategyBuilder;
 import com.spectralogic.ds3client.models.BulkObject;
@@ -31,7 +32,11 @@ import com.spectralogic.ds3client.models.Objects;
 import com.spectralogic.ds3client.models.Priority;
 import com.spectralogic.ds3client.utils.ByteArraySeekableByteChannel;
 import org.junit.Test;
+
+import static com.spectralogic.ds3client.helpers.ResponseBuilders.availableJobChunks;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -112,13 +117,10 @@ public class Metadata_Test {
             }
         };
 
-        final AllocateJobChunkSpectraS3Response allocateJobChunkSpectraS3Response = new AllocateJobChunkSpectraS3Response(
-                chunk, 0, AllocateJobChunkSpectraS3Response.Status.ALLOCATED, "checksum", ChecksumType.Type.NONE
-        );
-
         final Ds3Client ds3Client = Mockito.mock(Ds3Client.class);
-        Mockito.when(ds3Client.allocateJobChunkSpectraS3(Mockito.any(AllocateJobChunkSpectraS3Request.class)))
-                .thenReturn(allocateJobChunkSpectraS3Response);
+        final GetJobChunksReadyForClientProcessingSpectraS3Response availableChunks = availableJobChunks(masterObjectList);
+        Mockito.when(ds3Client.getJobChunksReadyForClientProcessingSpectraS3(any()))
+                .thenReturn(availableChunks);
 
         final AtomicInteger numBlobsForWhichWeGotMetadata = new AtomicInteger(0);
 

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/RequestMatchers.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/RequestMatchers.java
@@ -94,32 +94,6 @@ public final class RequestMatchers {
         });
     }
 
-    public static AllocateJobChunkSpectraS3Request hasChunkId(final UUID chunkId) {
-        return argThat(new TypeSafeMatcher<AllocateJobChunkSpectraS3Request>() {
-            @Override
-            public void describeTo(final Description description) {
-                describeRequest(chunkId, description);
-            }
-
-            @Override
-            protected boolean matchesSafely(final AllocateJobChunkSpectraS3Request item) {
-                return chunkId.equals(UUID.fromString(item.getJobChunkId()));
-            }
-            
-            @Override
-            protected void describeMismatchSafely(
-                    final AllocateJobChunkSpectraS3Request item,
-                    final Description mismatchDescription) {
-                describeRequest(UUID.fromString(item.getJobChunkId()), mismatchDescription);
-            }
-
-            private void describeRequest(final UUID chunkIdValue, final Description description) {
-                description
-                    .appendText("AllocateJobChunkResponse with chunk id: ")
-                    .appendValue(chunkIdValue);
-            }
-        });
-    }
 
     public static GetObjectRequest getRequestHas(final String bucket, final String key, final UUID jobId, final long offset) {
         return argThat(new TypeSafeMatcher<GetObjectRequest>() {

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/ResponseBuilders.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/ResponseBuilders.java
@@ -73,20 +73,7 @@ public final class ResponseBuilders {
         when(response.getRetryAfterSeconds()).thenReturn(retryAfterInSeconds);
         return response;
     }
-    
-    public static AllocateJobChunkSpectraS3Response allocated(final Objects chunk) {
-        final AllocateJobChunkSpectraS3Response response = mock(AllocateJobChunkSpectraS3Response.class);
-        when(response.getStatus()).thenReturn(AllocateJobChunkSpectraS3Response.Status.ALLOCATED);
-        when(response.getObjectsResult()).thenReturn(chunk);
-        return response;
-    }
-    
-    public static AllocateJobChunkSpectraS3Response retryAllocateLater(final int retryAfterInSeconds) {
-        final AllocateJobChunkSpectraS3Response response = mock(AllocateJobChunkSpectraS3Response.class);
-        when(response.getStatus()).thenReturn(AllocateJobChunkSpectraS3Response.Status.RETRYLATER);
-        when(response.getRetryAfterSeconds()).thenReturn(retryAfterInSeconds);
-        return response;
-    }
+
     
     public static MasterObjectList jobResponse(
             final UUID jobId,

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy_Test.java
@@ -1,0 +1,226 @@
+package com.spectralogic.ds3client.helpers.strategy.blobstrategy;
+
+import com.google.common.collect.Lists;
+import com.spectralogic.ds3client.Ds3Client;
+import com.spectralogic.ds3client.commands.spectrads3.GetJobChunksReadyForClientProcessingSpectraS3Request;
+import com.spectralogic.ds3client.commands.spectrads3.GetJobChunksReadyForClientProcessingSpectraS3Response;
+import com.spectralogic.ds3client.helpers.JobPart;
+import com.spectralogic.ds3client.helpers.strategy.transferstrategy.EventDispatcher;
+import com.spectralogic.ds3client.models.BulkObject;
+import com.spectralogic.ds3client.models.MasterObjectList;
+import com.spectralogic.ds3client.models.Objects;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class PutBlobStrategy_Test {
+
+    @Test
+    public void testGetWorkWithDuplicates() throws IOException, InterruptedException {
+        final Ds3Client client = mock(Ds3Client.class);
+        final MasterObjectList mol = mock(MasterObjectList.class);
+        final EventDispatcher eventDispatcher = mock(EventDispatcher.class);
+        final ChunkAttemptRetryBehavior retryBehavior = mock(ChunkAttemptRetryBehavior.class);
+        final ChunkAttemptRetryDelayBehavior retryDelayBehavior = mock(ChunkAttemptRetryDelayBehavior.class);
+
+        final UUID jobId = UUID.randomUUID();
+        when(mol.getJobId()).thenReturn(jobId);
+
+        final UUID objectId = UUID.randomUUID();
+        final BulkObject blob1 = new BulkObject();
+        blob1.setId(objectId);
+        blob1.setOffset(0);
+        blob1.setInCache(false);
+
+        final BulkObject blob2 = new BulkObject();
+        blob2.setId(objectId);
+        blob2.setOffset(100);
+        blob2.setInCache(false);
+
+        final Objects chunk = new Objects();
+        chunk.setObjects(Lists.newArrayList(blob1, blob2));
+
+        final MasterObjectList molResult = mock(MasterObjectList.class);
+        when(molResult.getObjects()).thenReturn(Lists.newArrayList(chunk));
+
+        final GetJobChunksReadyForClientProcessingSpectraS3Response realResponse = new GetJobChunksReadyForClientProcessingSpectraS3Response(molResult, 0, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE, null, null);
+        when(client.getJobChunksReadyForClientProcessingSpectraS3(any(GetJobChunksReadyForClientProcessingSpectraS3Request.class)))
+                .thenReturn(realResponse);
+
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, false);
+
+        final List<JobPart> work = Lists.newArrayList(strategy.getWork());
+
+        assertThat(work.size(), is(2));
+        assertThat(work.get(0).getBlob().getId(), is(objectId));
+        assertThat(work.get(1).getBlob().getId(), is(objectId));
+    }
+
+    @Test
+    public void testGetWorkWithDuplicatesSequential() throws IOException, InterruptedException {
+        final Ds3Client client = mock(Ds3Client.class);
+        final MasterObjectList mol = mock(MasterObjectList.class);
+        final EventDispatcher eventDispatcher = mock(EventDispatcher.class);
+        final ChunkAttemptRetryBehavior retryBehavior = mock(ChunkAttemptRetryBehavior.class);
+        final ChunkAttemptRetryDelayBehavior retryDelayBehavior = mock(ChunkAttemptRetryDelayBehavior.class);
+
+        final UUID jobId = UUID.randomUUID();
+        when(mol.getJobId()).thenReturn(jobId);
+
+        final UUID objectId = UUID.randomUUID();
+        final BulkObject blob1 = new BulkObject();
+        blob1.setId(objectId);
+        blob1.setOffset(0);
+        blob1.setInCache(false);
+
+        final BulkObject blob2 = new BulkObject();
+        blob2.setId(objectId);
+        blob2.setOffset(100);
+        blob2.setInCache(false);
+
+        final Objects chunk = new Objects();
+        chunk.setObjects(Lists.newArrayList(blob1, blob2));
+
+        final MasterObjectList molResult = mock(MasterObjectList.class);
+        when(molResult.getObjects()).thenReturn(Lists.newArrayList(chunk));
+
+        final GetJobChunksReadyForClientProcessingSpectraS3Response realResponse = new GetJobChunksReadyForClientProcessingSpectraS3Response(molResult, 0, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE, null, null);
+
+        when(client.getJobChunksReadyForClientProcessingSpectraS3(any(GetJobChunksReadyForClientProcessingSpectraS3Request.class)))
+                .thenReturn(realResponse);
+
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, true);
+
+        final List<JobPart> work = Lists.newArrayList(strategy.getWork());
+
+        assertThat(work.size(), is(1));
+        assertThat(work.get(0).getBlob().getId(), is(objectId));
+        assertThat(work.get(0).getBlob().getOffset(), is(0L));
+    }
+
+    @Test
+    public void testGetWorkRetryLater() throws IOException, InterruptedException {
+        final Ds3Client client = mock(Ds3Client.class);
+        final MasterObjectList mol = mock(MasterObjectList.class);
+        final EventDispatcher eventDispatcher = mock(EventDispatcher.class);
+        final ChunkAttemptRetryBehavior retryBehavior = mock(ChunkAttemptRetryBehavior.class);
+        final ChunkAttemptRetryDelayBehavior retryDelayBehavior = mock(ChunkAttemptRetryDelayBehavior.class);
+
+        final UUID jobId = UUID.randomUUID();
+        when(mol.getJobId()).thenReturn(jobId);
+
+        final int retryAfterSeconds = 10;
+        final GetJobChunksReadyForClientProcessingSpectraS3Response retryLaterResponse = new GetJobChunksReadyForClientProcessingSpectraS3Response(
+                null, retryAfterSeconds, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.RETRYLATER, null, null);
+
+        final MasterObjectList molResult = mock(MasterObjectList.class);
+        when(molResult.getObjects()).thenReturn(Lists.newArrayList());
+        final GetJobChunksReadyForClientProcessingSpectraS3Response availableResponse = new GetJobChunksReadyForClientProcessingSpectraS3Response(
+                molResult, 0, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE, null, null);
+
+        when(client.getJobChunksReadyForClientProcessingSpectraS3(any(GetJobChunksReadyForClientProcessingSpectraS3Request.class)))
+                .thenReturn(retryLaterResponse)
+                .thenReturn(availableResponse);
+
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, false);
+
+        final List<JobPart> work = Lists.newArrayList(strategy.getWork());
+
+        assertThat(work.isEmpty(), is(true));
+        verify(retryBehavior).invoke();
+        verify(retryDelayBehavior).delay(retryAfterSeconds);
+        verify(retryBehavior).reset();
+    }
+
+    @Test
+    public void testGetWorkFiltersInCache() throws IOException, InterruptedException {
+        final Ds3Client client = mock(Ds3Client.class);
+        final MasterObjectList mol = mock(MasterObjectList.class);
+        final EventDispatcher eventDispatcher = mock(EventDispatcher.class);
+        final ChunkAttemptRetryBehavior retryBehavior = mock(ChunkAttemptRetryBehavior.class);
+        final ChunkAttemptRetryDelayBehavior retryDelayBehavior = mock(ChunkAttemptRetryDelayBehavior.class);
+
+        final UUID jobId = UUID.randomUUID();
+        when(mol.getJobId()).thenReturn(jobId);
+
+        final BulkObject blob1 = new BulkObject();
+        blob1.setId(UUID.randomUUID());
+        blob1.setInCache(true);
+
+        final BulkObject blob2 = new BulkObject();
+        blob2.setId(UUID.randomUUID());
+        blob2.setInCache(false);
+
+        final Objects chunk = new Objects();
+        chunk.setObjects(Lists.newArrayList(blob1, blob2));
+
+        final MasterObjectList molResult = mock(MasterObjectList.class);
+        when(molResult.getObjects()).thenReturn(Lists.newArrayList(chunk));
+
+        final GetJobChunksReadyForClientProcessingSpectraS3Response response = new GetJobChunksReadyForClientProcessingSpectraS3Response(
+                molResult, 0, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE, null, null);
+
+        when(client.getJobChunksReadyForClientProcessingSpectraS3(any(GetJobChunksReadyForClientProcessingSpectraS3Request.class)))
+                .thenReturn(response);
+
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, false);
+
+        final List<JobPart> work = Lists.newArrayList(strategy.getWork());
+
+        assertThat(work.size(), is(1));
+        assertThat(work.get(0).getBlob().getId(), is(blob2.getId()));
+        verify(retryBehavior).reset();
+    }
+
+    @Test
+    public void testBlobCompletedDoesNothing() {
+        final Ds3Client client = mock(Ds3Client.class);
+        final MasterObjectList mol = mock(MasterObjectList.class);
+        final EventDispatcher eventDispatcher = mock(EventDispatcher.class);
+        final ChunkAttemptRetryBehavior retryBehavior = mock(ChunkAttemptRetryBehavior.class);
+        final ChunkAttemptRetryDelayBehavior retryDelayBehavior = mock(ChunkAttemptRetryDelayBehavior.class);
+
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, false);
+        strategy.blobCompleted(new BulkObject());
+
+        // We expect an interaction in the constructor of AbstractBlobStrategy
+        verify(eventDispatcher).attachBlobTransferredEventObserver(any());
+        
+        // No other interactions
+        verifyNoInteractions(client, mol, retryBehavior, retryDelayBehavior);
+    }
+    @Test
+    public void testGetWorkEmptyResponse() throws IOException, InterruptedException {
+        final Ds3Client client = mock(Ds3Client.class);
+        final MasterObjectList mol = mock(MasterObjectList.class);
+        final EventDispatcher eventDispatcher = mock(EventDispatcher.class);
+        final ChunkAttemptRetryBehavior retryBehavior = mock(ChunkAttemptRetryBehavior.class);
+        final ChunkAttemptRetryDelayBehavior retryDelayBehavior = mock(ChunkAttemptRetryDelayBehavior.class);
+
+        final UUID jobId = UUID.randomUUID();
+        when(mol.getJobId()).thenReturn(jobId);
+
+        final MasterObjectList molResult = mock(MasterObjectList.class);
+        when(molResult.getObjects()).thenReturn(Lists.newArrayList());
+
+        final GetJobChunksReadyForClientProcessingSpectraS3Response response = new GetJobChunksReadyForClientProcessingSpectraS3Response(
+                molResult, 0, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE, null, null);
+
+        when(client.getJobChunksReadyForClientProcessingSpectraS3(any(GetJobChunksReadyForClientProcessingSpectraS3Request.class)))
+                .thenReturn(response);
+
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, false);
+
+        final List<JobPart> work = Lists.newArrayList(strategy.getWork());
+
+        assertThat(work.isEmpty(), is(true));
+        verify(retryBehavior).reset();
+    }
+}

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy_Test.java
@@ -5,6 +5,7 @@ import com.spectralogic.ds3client.Ds3Client;
 import com.spectralogic.ds3client.commands.spectrads3.GetJobChunksReadyForClientProcessingSpectraS3Request;
 import com.spectralogic.ds3client.commands.spectrads3.GetJobChunksReadyForClientProcessingSpectraS3Response;
 import com.spectralogic.ds3client.helpers.JobPart;
+import com.spectralogic.ds3client.helpers.JobState;
 import com.spectralogic.ds3client.helpers.strategy.transferstrategy.EventDispatcher;
 import com.spectralogic.ds3client.models.BulkObject;
 import com.spectralogic.ds3client.models.MasterObjectList;
@@ -54,7 +55,7 @@ public class PutBlobStrategy_Test {
         when(client.getJobChunksReadyForClientProcessingSpectraS3(any(GetJobChunksReadyForClientProcessingSpectraS3Request.class)))
                 .thenReturn(realResponse);
 
-        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, false);
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, new JobState(molResult.getObjects()), false);
 
         final List<JobPart> work = Lists.newArrayList(strategy.getWork());
 
@@ -96,7 +97,7 @@ public class PutBlobStrategy_Test {
         when(client.getJobChunksReadyForClientProcessingSpectraS3(any(GetJobChunksReadyForClientProcessingSpectraS3Request.class)))
                 .thenReturn(realResponse);
 
-        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, true);
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, new JobState(molResult.getObjects()), true);
 
         final List<JobPart> work = Lists.newArrayList(strategy.getWork());
 
@@ -129,7 +130,7 @@ public class PutBlobStrategy_Test {
                 .thenReturn(retryLaterResponse)
                 .thenReturn(availableResponse);
 
-        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, false);
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, new JobState(molResult.getObjects()), false);
 
         final List<JobPart> work = Lists.newArrayList(strategy.getWork());
 
@@ -170,7 +171,7 @@ public class PutBlobStrategy_Test {
         when(client.getJobChunksReadyForClientProcessingSpectraS3(any(GetJobChunksReadyForClientProcessingSpectraS3Request.class)))
                 .thenReturn(response);
 
-        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, false);
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, new JobState(molResult.getObjects()), false);
 
         final List<JobPart> work = Lists.newArrayList(strategy.getWork());
 
@@ -187,14 +188,16 @@ public class PutBlobStrategy_Test {
         final ChunkAttemptRetryBehavior retryBehavior = mock(ChunkAttemptRetryBehavior.class);
         final ChunkAttemptRetryDelayBehavior retryDelayBehavior = mock(ChunkAttemptRetryDelayBehavior.class);
 
-        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, false);
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, new JobState(mol.getObjects()), false);
         strategy.blobCompleted(new BulkObject());
 
         // We expect an interaction in the constructor of AbstractBlobStrategy
         verify(eventDispatcher).attachBlobTransferredEventObserver(any());
-        
+
+        verify(mol).getObjects();
+
         // No other interactions
-        verifyNoInteractions(client, mol, retryBehavior, retryDelayBehavior);
+        verifyNoMoreInteractions(client, mol, retryBehavior, retryDelayBehavior);
     }
     @Test
     public void testGetWorkEmptyResponse() throws IOException, InterruptedException {
@@ -216,7 +219,7 @@ public class PutBlobStrategy_Test {
         when(client.getJobChunksReadyForClientProcessingSpectraS3(any(GetJobChunksReadyForClientProcessingSpectraS3Request.class)))
                 .thenReturn(response);
 
-        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, false);
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, new JobState(molResult.getObjects()), false);
 
         final List<JobPart> work = Lists.newArrayList(strategy.getWork());
 

--- a/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy_Test.java
+++ b/ds3-sdk/src/test/java/com/spectralogic/ds3client/helpers/strategy/blobstrategy/PutBlobStrategy_Test.java
@@ -109,34 +109,53 @@ public class PutBlobStrategy_Test {
     @Test
     public void testGetWorkRetryLater() throws IOException, InterruptedException {
         final Ds3Client client = mock(Ds3Client.class);
-        final MasterObjectList mol = mock(MasterObjectList.class);
-        final EventDispatcher eventDispatcher = mock(EventDispatcher.class);
+        final MasterObjectList mol = new MasterObjectList();
+        mol.setJobId(UUID.randomUUID());
         final ChunkAttemptRetryBehavior retryBehavior = mock(ChunkAttemptRetryBehavior.class);
         final ChunkAttemptRetryDelayBehavior retryDelayBehavior = mock(ChunkAttemptRetryDelayBehavior.class);
 
-        final UUID jobId = UUID.randomUUID();
-        when(mol.getJobId()).thenReturn(jobId);
-
         final int retryAfterSeconds = 10;
-        final GetJobChunksReadyForClientProcessingSpectraS3Response retryLaterResponse = new GetJobChunksReadyForClientProcessingSpectraS3Response(
-                null, retryAfterSeconds, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.RETRYLATER, null, null);
+        final MasterObjectList emptyMol = new MasterObjectList();
 
-        final MasterObjectList molResult = mock(MasterObjectList.class);
-        when(molResult.getObjects()).thenReturn(Lists.newArrayList());
-        final GetJobChunksReadyForClientProcessingSpectraS3Response availableResponse = new GetJobChunksReadyForClientProcessingSpectraS3Response(
-                molResult, 0, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE, null, null);
+        when(client.getJobChunksReadyForClientProcessingSpectraS3(any()))
+                .thenReturn(new GetJobChunksReadyForClientProcessingSpectraS3Response(null, retryAfterSeconds, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.RETRYLATER, null, null))
+                .thenReturn(new GetJobChunksReadyForClientProcessingSpectraS3Response(emptyMol, 0, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE, null, null));
 
-        when(client.getJobChunksReadyForClientProcessingSpectraS3(any(GetJobChunksReadyForClientProcessingSpectraS3Request.class)))
-                .thenReturn(retryLaterResponse)
-                .thenReturn(availableResponse);
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, mock(EventDispatcher.class), retryBehavior, retryDelayBehavior, new JobState(emptyMol.getObjects()), false);
 
-        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, eventDispatcher, retryBehavior, retryDelayBehavior, new JobState(molResult.getObjects()), false);
+        assertThat(Lists.newArrayList(strategy.getWork()).isEmpty(), is(true));
 
-        final List<JobPart> work = Lists.newArrayList(strategy.getWork());
-
-        assertThat(work.isEmpty(), is(true));
         verify(retryBehavior).invoke();
         verify(retryDelayBehavior).delay(retryAfterSeconds);
+        verify(retryBehavior).reset();
+    }
+
+    @Test
+    public void testGetWorkAvailableWithNoWork() throws IOException, InterruptedException {
+        final Ds3Client client = mock(Ds3Client.class);
+        final MasterObjectList mol = new MasterObjectList();
+        mol.setJobId(UUID.randomUUID());
+        final ChunkAttemptRetryBehavior retryBehavior = mock(ChunkAttemptRetryBehavior.class);
+        final ChunkAttemptRetryDelayBehavior retryDelayBehavior = mock(ChunkAttemptRetryDelayBehavior.class);
+
+        final BulkObject blob = new BulkObject();
+        blob.setId(UUID.randomUUID());
+        blob.setInCache(false);
+        final Objects chunk = new Objects();
+        chunk.setObjects(Lists.newArrayList(blob));
+        final MasterObjectList molWithWork = new MasterObjectList();
+        molWithWork.setObjects(Lists.newArrayList(chunk));
+
+        when(client.getJobChunksReadyForClientProcessingSpectraS3(any()))
+                .thenReturn(new GetJobChunksReadyForClientProcessingSpectraS3Response(new MasterObjectList(), 0, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE, null, null))
+                .thenReturn(new GetJobChunksReadyForClientProcessingSpectraS3Response(molWithWork, 0, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE, null, null));
+
+        final PutBlobStrategy strategy = new PutBlobStrategy(client, mol, mock(EventDispatcher.class), retryBehavior, retryDelayBehavior, new JobState(molWithWork.getObjects()), false);
+
+        assertThat(Lists.newArrayList(strategy.getWork()).size(), is(1));
+
+        verify(retryBehavior).invoke();
+        verify(retryDelayBehavior).delay(1);
         verify(retryBehavior).reset();
     }
 


### PR DESCRIPTION
- Deprecated `AllocateJobChunk` call and the helpers strategy `PutSequentialBlobStrategy` which relied on it.
- Created new helper `PutBlobStrategy` which uses `GetJobChunksReadyForClientProcessing`.
- Updated helper default to use the new `PutBlobStrategy`.
- Updated helper tests to use the new `PutBlobStrategy`.
- Updated integration tests to be more resilient in test setup.